### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/193/447/421193447.geojson
+++ b/data/421/193/447/421193447.geojson
@@ -199,6 +199,9 @@
     },
     "wof:country":"GY",
     "wof:created":1459009771,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"fd872fc1b2a55e0e615df221f15a17b8",
     "wof:hierarchy":[
         {
@@ -217,7 +220,7 @@
         }
     ],
     "wof:id":421193447,
-    "wof:lastmodified":1561845086,
+    "wof:lastmodified":1582313377,
     "wof:name":"Lethem",
     "wof:parent_id":1091681781,
     "wof:placetype":"locality",

--- a/data/856/323/97/85632397.geojson
+++ b/data/856/323/97/85632397.geojson
@@ -954,6 +954,11 @@
     },
     "wof:country":"GY",
     "wof:country_alpha3":"GUY",
+    "wof:geom_alt":[
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6",
+        "meso"
+    ],
     "wof:geomhash":"8a4a241c132a91ad3b15e26f155c05a8",
     "wof:hierarchy":[
         {
@@ -968,7 +973,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566644331,
+    "wof:lastmodified":1582313374,
     "wof:name":"Guyana",
     "wof:parent_id":102191577,
     "wof:placetype":"country",

--- a/data/856/717/37/85671737.geojson
+++ b/data/856/717/37/85671737.geojson
@@ -248,6 +248,9 @@
         "wof:parent_id"
     ],
     "wof:country":"GY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f5d53c2e437781d0f801e157389f1858",
     "wof:hierarchy":[
         {
@@ -263,7 +266,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566644336,
+    "wof:lastmodified":1582313376,
     "wof:name":"Mahaica-Berbice",
     "wof:parent_id":85632397,
     "wof:placetype":"region",

--- a/data/856/717/39/85671739.geojson
+++ b/data/856/717/39/85671739.geojson
@@ -270,6 +270,9 @@
         "wk:page":"Potaro-Siparuni"
     },
     "wof:country":"GY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2871ddde302c5bf0bc06d8383a9beffe",
     "wof:hierarchy":[
         {
@@ -285,7 +288,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566644336,
+    "wof:lastmodified":1582313376,
     "wof:name":"Potaro-Siparuni",
     "wof:parent_id":85632397,
     "wof:placetype":"region",

--- a/data/856/717/43/85671743.geojson
+++ b/data/856/717/43/85671743.geojson
@@ -252,6 +252,9 @@
         "wk:page":"Upper Demerara-Berbice"
     },
     "wof:country":"GY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4af0526d94a4d41a73a0b25b6ceb0710",
     "wof:hierarchy":[
         {
@@ -267,7 +270,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566644335,
+    "wof:lastmodified":1582313376,
     "wof:name":"Upper Takutu-Upper Essequibo",
     "wof:parent_id":85632397,
     "wof:placetype":"region",

--- a/data/856/717/45/85671745.geojson
+++ b/data/856/717/45/85671745.geojson
@@ -249,6 +249,9 @@
         "wk:page":"Upper Takutu-Upper Essequibo"
     },
     "wof:country":"GY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2bfea6fa01cab4837f5a7d966c997eb6",
     "wof:hierarchy":[
         {
@@ -264,7 +267,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566644334,
+    "wof:lastmodified":1582313375,
     "wof:name":"Upper Demerara-Berbice",
     "wof:parent_id":85632397,
     "wof:placetype":"region",

--- a/data/856/717/51/85671751.geojson
+++ b/data/856/717/51/85671751.geojson
@@ -273,6 +273,9 @@
         "wk:page":"Barima-Waini"
     },
     "wof:country":"GY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e20ef2800b44b18f32771587ea46a5fb",
     "wof:hierarchy":[
         {
@@ -288,7 +291,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566644334,
+    "wof:lastmodified":1582313375,
     "wof:name":"Barima-Waini",
     "wof:parent_id":85632397,
     "wof:placetype":"region",

--- a/data/856/717/53/85671753.geojson
+++ b/data/856/717/53/85671753.geojson
@@ -255,6 +255,9 @@
         "wk:page":"Cuyuni-Mazaruni"
     },
     "wof:country":"GY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c879da06731fe0dd05d3d122ed9b0b5d",
     "wof:hierarchy":[
         {
@@ -270,7 +273,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566644336,
+    "wof:lastmodified":1582313376,
     "wof:name":"Pomeroon-Supenaam",
     "wof:parent_id":85632397,
     "wof:placetype":"region",

--- a/data/856/717/57/85671757.geojson
+++ b/data/856/717/57/85671757.geojson
@@ -258,6 +258,9 @@
         "wk:page":"Demerara-Mahaica"
     },
     "wof:country":"GY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"48f5f54e2ffc3f37dcb91cb7346b2250",
     "wof:hierarchy":[
         {
@@ -273,7 +276,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566644333,
+    "wof:lastmodified":1582313375,
     "wof:name":"East Berbice-Corentyne",
     "wof:parent_id":-1,
     "wof:placetype":"region",

--- a/data/856/717/61/85671761.geojson
+++ b/data/856/717/61/85671761.geojson
@@ -162,6 +162,9 @@
         "wk:page":"Essequibo Islands-West Demerara"
     },
     "wof:country":"GY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f89dacbe729e8eb7a5d852686c8ce383",
     "wof:hierarchy":[
         {
@@ -177,7 +180,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566644333,
+    "wof:lastmodified":1582313374,
     "wof:name":"Demerara-Mahaica",
     "wof:parent_id":85632397,
     "wof:placetype":"region",

--- a/data/856/717/67/85671767.geojson
+++ b/data/856/717/67/85671767.geojson
@@ -204,6 +204,9 @@
         "wk:page":"Mahaica-Berbice"
     },
     "wof:country":"GY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a19b1d0e991f975f617140be1acf487b",
     "wof:hierarchy":[
         {
@@ -219,7 +222,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566644334,
+    "wof:lastmodified":1582313375,
     "wof:name":"Essequibo Islands-West Demerara",
     "wof:parent_id":85632397,
     "wof:placetype":"region",

--- a/data/856/717/73/85671773.geojson
+++ b/data/856/717/73/85671773.geojson
@@ -255,6 +255,9 @@
         "wk:page":"Pomeroon-Supenaam"
     },
     "wof:country":"GY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a467d5e83a10dd637bc1e52f79a0330a",
     "wof:hierarchy":[
         {
@@ -270,7 +273,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566644335,
+    "wof:lastmodified":1582313375,
     "wof:name":"Cuyuni-Mazaruni",
     "wof:parent_id":85632397,
     "wof:placetype":"region",

--- a/data/857/648/33/85764833.geojson
+++ b/data/857/648/33/85764833.geojson
@@ -65,6 +65,9 @@
         "gp:id":376345
     },
     "wof:country":"GY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9782bd4e4eee65afcbe6e326dd3fabdc",
     "wof:hierarchy":[
         {
@@ -80,7 +83,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566644331,
+    "wof:lastmodified":1582313373,
     "wof:name":"Albouystown",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/648/37/85764837.geojson
+++ b/data/857/648/37/85764837.geojson
@@ -65,6 +65,9 @@
         "gp:id":376398
     },
     "wof:country":"GY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2f2e739e823850f7010e79ad5c15c5ed",
     "wof:hierarchy":[
         {
@@ -80,7 +83,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566644331,
+    "wof:lastmodified":1582313373,
     "wof:name":"Blygezight",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/648/41/85764841.geojson
+++ b/data/857/648/41/85764841.geojson
@@ -82,6 +82,9 @@
         "wd:id":"Q895200"
     },
     "wof:country":"GY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"be3aa9a979f85c1df54591cbd6841c2a",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566644331,
+    "wof:lastmodified":1582313373,
     "wof:name":"Bourda",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/648/45/85764845.geojson
+++ b/data/857/648/45/85764845.geojson
@@ -93,6 +93,9 @@
         "qs_pg:id":1117085
     },
     "wof:country":"GY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c3447d4a8dc4d2e5b745912e52f9d32d",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566644331,
+    "wof:lastmodified":1582313373,
     "wof:name":"Cummingsburg",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/648/49/85764849.geojson
+++ b/data/857/648/49/85764849.geojson
@@ -65,6 +65,9 @@
         "gp:id":376540
     },
     "wof:country":"GY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3a7aca11e9395703c53867082b1c8b4b",
     "wof:hierarchy":[
         {
@@ -80,7 +83,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566644331,
+    "wof:lastmodified":1582313373,
     "wof:name":"La Penitence",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/648/53/85764853.geojson
+++ b/data/857/648/53/85764853.geojson
@@ -73,6 +73,9 @@
         "qs:id":1117086
     },
     "wof:country":"GY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"911bec7a93bfab209b0f35fcca4b3ae9",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379333,
+    "wof:lastmodified":1582313373,
     "wof:name":"Robbstown",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/648/57/85764857.geojson
+++ b/data/857/648/57/85764857.geojson
@@ -92,6 +92,9 @@
         "qs_pg:id":501436
     },
     "wof:country":"GY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"25e983c1f34d0b9fc5576f6716ab226b",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566644330,
+    "wof:lastmodified":1582313373,
     "wof:name":"Smythfield",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/648/63/85764863.geojson
+++ b/data/857/648/63/85764863.geojson
@@ -78,6 +78,9 @@
         "wk:page":"Stabroek, Guyana"
     },
     "wof:country":"GY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"419533b2c1ece41872a5178e24518e29",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379333,
+    "wof:lastmodified":1582313373,
     "wof:name":"Stabroek",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/440/115/890440115.geojson
+++ b/data/890/440/115/890440115.geojson
@@ -176,6 +176,9 @@
     },
     "wof:country":"GY",
     "wof:created":1469052263,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"50732f1ff5f802d38cc7c1d833bd6617",
     "wof:hierarchy":[
         {
@@ -187,7 +190,7 @@
         }
     ],
     "wof:id":890440115,
-    "wof:lastmodified":1561845086,
+    "wof:lastmodified":1582313378,
     "wof:name":"Mabaruma",
     "wof:parent_id":1091681147,
     "wof:placetype":"locality",

--- a/data/890/444/585/890444585.geojson
+++ b/data/890/444/585/890444585.geojson
@@ -509,6 +509,9 @@
     },
     "wof:country":"GY",
     "wof:created":1469052474,
+    "wof:geom_alt":[
+        "unknown"
+    ],
     "wof:geomhash":"aea4e9814d5a5896364a0d5e51fcf08a",
     "wof:hierarchy":[
         {
@@ -520,7 +523,7 @@
         }
     ],
     "wof:id":890444585,
-    "wof:lastmodified":1566644395,
+    "wof:lastmodified":1582313378,
     "wof:name":"Georgetown",
     "wof:parent_id":1091683403,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.