### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/102/544/287/102544287.geojson
+++ b/data/102/544/287/102544287.geojson
@@ -13,6 +13,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":13.0,
+    "name:cym_x_preferred":[
+        "Maes Awyr Rhyngwladol Kaieteur"
+    ],
     "name:eng_x_variant":[
         "KAI",
         "SYKA"
@@ -66,7 +69,7 @@
         }
     ],
     "wof:id":102544287,
-    "wof:lastmodified":1631743684,
+    "wof:lastmodified":1690930160,
     "wof:name":"Kaieteur Airport",
     "wof:parent_id":85671739,
     "wof:placetype":"campus",

--- a/data/112/607/372/1/1126073721.geojson
+++ b/data/112/607/372/1/1126073721.geojson
@@ -26,6 +26,15 @@
     "name:eng_x_preferred":[
         "Stabroek"
     ],
+    "name:nld_x_preferred":[
+        "Stabroek"
+    ],
+    "name:rus_x_preferred":[
+        "\u0421\u0442\u0430\u0431\u0440\u0443\u043a"
+    ],
+    "name:ukr_x_preferred":[
+        "\u0421\u0442\u0430\u0431\u0440\u0443\u043a"
+    ],
     "qs_pg:aaroncc":"GY",
     "qs_pg:gn_country":"GY",
     "qs_pg:gn_fcode":"PPLX",
@@ -80,7 +89,7 @@
         }
     ],
     "wof:id":1126073721,
-    "wof:lastmodified":1566644395,
+    "wof:lastmodified":1690930167,
     "wof:name":"Stabroek",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/114/190/636/7/1141906367.geojson
+++ b/data/114/190/636/7/1141906367.geojson
@@ -21,6 +21,9 @@
     "name:ara_x_preferred":[
         "\u0643\u0648\u0631\u064a\u0641\u064a\u0631\u062a\u0648\u0646"
     ],
+    "name:ast_x_preferred":[
+        "Corriverton"
+    ],
     "name:ben_x_preferred":[
         "\u0995\u09cb\u09b0\u09bf\u09ad\u09c7\u09b0\u099f\u09a8"
     ],
@@ -60,6 +63,9 @@
     "name:jpn_x_preferred":[
         "\u30b3\u30ea\u30d0\u30fc\u30c8\u30f3"
     ],
+    "name:kaz_x_preferred":[
+        "\u041a\u043e\u0440\u0440\u0438\u0432\u0435\u0440\u0442\u043e\u043d"
+    ],
     "name:kor_x_preferred":[
         "\ucf54\ub9ac\ubca0\ub974\ud134"
     ],
@@ -77,6 +83,9 @@
     ],
     "name:por_x_preferred":[
         "Corriverton"
+    ],
+    "name:rus_x_preferred":[
+        "\u041a\u043e\u0440\u0440\u0438\u0432\u0435\u0440\u0442\u043e\u043d"
     ],
     "name:slk_x_preferred":[
         "Corriverton"
@@ -223,7 +232,7 @@
         }
     ],
     "wof:id":1141906367,
-    "wof:lastmodified":1636494761,
+    "wof:lastmodified":1690930169,
     "wof:name":"Corriverton",
     "wof:parent_id":1091685409,
     "wof:placetype":"locality",

--- a/data/114/190/636/9/1141906369.geojson
+++ b/data/114/190/636/9/1141906369.geojson
@@ -21,6 +21,9 @@
     "name:ara_x_preferred":[
         "\u0625\u064a\u062a\u064a\u0648\u0646\u064a"
     ],
+    "name:ast_x_preferred":[
+        "Ituni"
+    ],
     "name:ben_x_preferred":[
         "\u0986\u0987\u09a4\u09c1\u09a8\u09bf"
     ],
@@ -221,7 +224,7 @@
         }
     ],
     "wof:id":1141906369,
-    "wof:lastmodified":1636494761,
+    "wof:lastmodified":1690930168,
     "wof:name":"Ituni",
     "wof:parent_id":1091684481,
     "wof:placetype":"locality",

--- a/data/114/190/637/1/1141906371.geojson
+++ b/data/114/190/637/1/1141906371.geojson
@@ -21,6 +21,9 @@
     "name:ara_x_preferred":[
         "\u0644\u064a\u062b\u064a\u0645"
     ],
+    "name:ast_x_preferred":[
+        "Lethem"
+    ],
     "name:ben_x_preferred":[
         "\u09b2\u09c7\u09a4\u09b9\u09c7\u09ae"
     ],
@@ -28,6 +31,9 @@
         "\u041b\u0435\u0442\u0445\u0435\u043c"
     ],
     "name:ceb_x_preferred":[
+        "Lethem"
+    ],
+    "name:deu_x_preferred":[
         "Lethem"
     ],
     "name:ell_x_preferred":[
@@ -38,6 +44,9 @@
     ],
     "name:fas_x_preferred":[
         "\u0644\u062a\u0645"
+    ],
+    "name:fin_x_preferred":[
+        "Lethem"
     ],
     "name:fra_x_preferred":[
         "Lethem"
@@ -59,6 +68,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30ec\u30bb\u30e0"
+    ],
+    "name:kaz_x_preferred":[
+        "\u041b\u0435\u0442\u0435\u043c"
     ],
     "name:kor_x_preferred":[
         "\ub808\ud15c"
@@ -237,7 +249,7 @@
         }
     ],
     "wof:id":1141906371,
-    "wof:lastmodified":1636494761,
+    "wof:lastmodified":1690930168,
     "wof:name":"Lethem",
     "wof:parent_id":1091681781,
     "wof:placetype":"locality",

--- a/data/114/190/695/7/1141906957.geojson
+++ b/data/114/190/695/7/1141906957.geojson
@@ -24,6 +24,12 @@
     "name:ara_x_preferred":[
         "\u0622\u0646\u0627 \u0631\u064a\u062c\u064a\u0646\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0622\u0646\u0627 \u0631\u064a\u062c\u064a\u0646\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "Anna Regina"
+    ],
     "name:ben_x_preferred":[
         "\u0985\u09cd\u09af\u09be\u09a8\u09cd\u09a8\u09be \u09b0\u09c7\u099c\u09bf\u09a8\u09be"
     ],
@@ -62,6 +68,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30a2\u30f3\u30ca\u30fb\u30ec\u30b8\u30e3\u30a4\u30ca"
+    ],
+    "name:kaz_x_preferred":[
+        "\u0410\u043d\u043d\u0430-\u0420\u0435\u0434\u0436\u0438\u043d\u0430"
     ],
     "name:kor_x_preferred":[
         "\uc560\ub098\ub808\uc9c0\ub098"
@@ -249,7 +258,7 @@
         }
     ],
     "wof:id":1141906957,
-    "wof:lastmodified":1636494761,
+    "wof:lastmodified":1690930168,
     "wof:name":"Anna Regina",
     "wof:parent_id":1091681277,
     "wof:placetype":"locality",

--- a/data/114/190/874/5/1141908745.geojson
+++ b/data/114/190/874/5/1141908745.geojson
@@ -24,6 +24,9 @@
     "name:ara_x_preferred":[
         "\u0645\u0627\u0628\u0627\u0631\u0648\u0645\u0627"
     ],
+    "name:ast_x_preferred":[
+        "Mabaruma"
+    ],
     "name:ben_x_preferred":[
         "\u09ae\u09be\u09ac\u09be\u09b0\u09c1\u09ae\u09be"
     ],
@@ -63,6 +66,9 @@
     "name:jpn_x_preferred":[
         "\u30de\u30d0\u30eb\u30de"
     ],
+    "name:kaz_x_preferred":[
+        "\u041c\u0430\u0431\u0430\u0440\u0443\u043c\u0430"
+    ],
     "name:kor_x_preferred":[
         "\ub9c8\ubc14\ub8e8\ub9c8"
     ],
@@ -70,6 +76,9 @@
         "Mabaruma"
     ],
     "name:nld_x_preferred":[
+        "Mabaruma"
+    ],
+    "name:pol_x_preferred":[
         "Mabaruma"
     ],
     "name:por_x_preferred":[
@@ -223,7 +232,7 @@
         }
     ],
     "wof:id":1141908745,
-    "wof:lastmodified":1636494761,
+    "wof:lastmodified":1690930168,
     "wof:name":"Mabaruma",
     "wof:parent_id":1091681147,
     "wof:placetype":"locality",

--- a/data/421/168/567/421168567.geojson
+++ b/data/421/168/567/421168567.geojson
@@ -17,6 +17,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ast_x_preferred":[
+        "Vreed en Hoop"
+    ],
     "name:ceb_x_preferred":[
         "Vreed-en-Hoop"
     ],
@@ -31,6 +34,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30d6\u30ea\u30fc\u30c9\u30fb\u30a8\u30f3\u30fb\u30db\u30fc\u30d7"
+    ],
+    "name:kaz_x_preferred":[
+        "\u0412\u0440\u0435\u0434-\u044d\u043d-\u0425\u0443\u043f"
     ],
     "name:lit_x_preferred":[
         "Vred en Hopas"
@@ -47,8 +53,14 @@
     "name:rus_x_preferred":[
         "\u0412\u0440\u0435\u0434-\u044d\u043d-\u0425\u0443\u043f"
     ],
+    "name:spa_x_preferred":[
+        "Vreed en Hoop"
+    ],
     "name:swe_x_preferred":[
         "Vreed-en-Hoop"
+    ],
+    "name:swe_x_variant":[
+        "Vreed en Hoop"
     ],
     "name:ukr_x_preferred":[
         "\u0412\u0440\u0435\u0434-\u0435\u043d-\u0425\u043e\u043f"
@@ -106,7 +118,7 @@
         }
     ],
     "wof:id":421168567,
-    "wof:lastmodified":1566644392,
+    "wof:lastmodified":1690930165,
     "wof:name":"Vreed en Hoop",
     "wof:parent_id":1091682307,
     "wof:placetype":"locality",

--- a/data/421/176/611/421176611.geojson
+++ b/data/421/176/611/421176611.geojson
@@ -20,6 +20,12 @@
     "name:ara_x_preferred":[
         "\u0644\u064a\u0646\u062f\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u0644\u064a\u0646\u062f\u0646"
+    ],
+    "name:ast_x_preferred":[
+        "Linden"
+    ],
     "name:ben_x_preferred":[
         "\u09b2\u09bf\u09a8\u09cd\u09a1\u09c7\u09a8"
     ],
@@ -77,6 +83,12 @@
     "name:kan_x_preferred":[
         "\u0cb2\u0cbf\u0c82\u0ca1\u0cc6\u0ca8\u0ccd"
     ],
+    "name:kat_x_preferred":[
+        "\u10da\u10d8\u10dc\u10d3\u10d4\u10dc\u10d8"
+    ],
+    "name:kaz_x_preferred":[
+        "\u041b\u0438\u043d\u0434\u0435\u043d"
+    ],
     "name:kor_x_preferred":[
         "\ub9b0\ub358"
     ],
@@ -107,6 +119,9 @@
     "name:por_x_preferred":[
         "Linden"
     ],
+    "name:ron_x_preferred":[
+        "Linden"
+    ],
     "name:rus_x_preferred":[
         "\u041b\u0438\u043d\u0434\u0435\u043d"
     ],
@@ -114,7 +129,7 @@
         "\u0dbd\u0dd2\u0db1\u0dca\u0da9\u0dd9\u0db1\u0dca"
     ],
     "name:sin_x_variant":[
-        "\u0dbd\u0dd2\u0db1\u0dca\u0da9\u0dd9\u0db1\u0dca"
+        "\u0dbd\u0dd2\u0db1\u0dca\u0da9\u0dd9\u0db1\u0dca "
     ],
     "name:spa_x_preferred":[
         "Linden"
@@ -294,7 +309,7 @@
         }
     ],
     "wof:id":421176611,
-    "wof:lastmodified":1636494759,
+    "wof:lastmodified":1690930165,
     "wof:name":"Linden",
     "wof:parent_id":1091685061,
     "wof:placetype":"locality",

--- a/data/856/323/97/85632397.geojson
+++ b/data/856/323/97/85632397.geojson
@@ -28,6 +28,9 @@
     "mz:is_current":1,
     "mz:max_zoom":9.0,
     "mz:min_zoom":4.0,
+    "name:abk_x_preferred":[
+        "\u0413\u0430\u0438\u0430\u043d\u0430"
+    ],
     "name:ace_x_preferred":[
         "Guyana"
     ],
@@ -40,6 +43,9 @@
     "name:aka_x_preferred":[
         "Gayana"
     ],
+    "name:aka_x_variant":[
+        "Guyana"
+    ],
     "name:als_x_preferred":[
         "Guyana"
     ],
@@ -49,8 +55,14 @@
     "name:amh_x_variant":[
         "\u1309\u12eb\u1293"
     ],
+    "name:ami_x_preferred":[
+        "Guyana"
+    ],
     "name:ang_x_preferred":[
         "Guyana"
+    ],
+    "name:anp_x_preferred":[
+        "\u0917\u0941\u092f\u093e\u0928\u093e"
     ],
     "name:ara_x_preferred":[
         "\u063a\u064a\u0627\u0646\u0627"
@@ -72,6 +84,9 @@
     ],
     "name:ast_x_preferred":[
         "Guyana"
+    ],
+    "name:awa_x_preferred":[
+        "\u0917\u092f\u093e\u0928\u093e"
     ],
     "name:aym_x_preferred":[
         "Wayana"
@@ -155,6 +170,9 @@
     "name:chv_x_preferred":[
         "\u0413\u0430\u0439\u0430\u043d\u0430"
     ],
+    "name:chy_x_preferred":[
+        "Guyana"
+    ],
     "name:ckb_x_preferred":[
         "\u06af\u0648\u06cc\u0627\u0646\u0627"
     ],
@@ -164,6 +182,9 @@
     "name:cor_x_preferred":[
         "Gwayana"
     ],
+    "name:cos_x_preferred":[
+        "Guyana"
+    ],
     "name:crh_x_preferred":[
         "Gayana"
     ],
@@ -171,6 +192,9 @@
         "Gaiana"
     ],
     "name:cym_x_variant":[
+        "Guyana"
+    ],
+    "name:dag_x_preferred":[
         "Guyana"
     ],
     "name:dan_x_preferred":[
@@ -265,6 +289,9 @@
     "name:ful_x_preferred":[
         "Giyaan"
     ],
+    "name:ful_x_variant":[
+        "Guyaana"
+    ],
     "name:gag_x_preferred":[
         "Gayana"
     ],
@@ -294,6 +321,9 @@
     ],
     "name:got_x_preferred":[
         "\ud800\udf35\ud800\udf30\ud800\udf3e\ud800\udf30\ud800\udf3d\ud800\udf30"
+    ],
+    "name:gpe_x_preferred":[
+        "Guyana"
     ],
     "name:grn_x_preferred":[
         "Guj\u00e1na"
@@ -467,6 +497,9 @@
     "name:lit_x_preferred":[
         "Gajana"
     ],
+    "name:lld_x_preferred":[
+        "Guyana"
+    ],
     "name:lmo_x_preferred":[
         "Gujana"
     ],
@@ -485,6 +518,9 @@
     "name:lzh_x_preferred":[
         "\u572d\u4e9e\u90a3"
     ],
+    "name:mad_x_preferred":[
+        "Guyana"
+    ],
     "name:mal_x_preferred":[
         "\u0d17\u0d2f\u0d3e\u0d28"
     ],
@@ -500,14 +536,26 @@
     "name:mhr_x_variant":[
         "\u0413\u0430\u0439\u0430\u043d\u0430"
     ],
+    "name:min_x_preferred":[
+        "Guyana"
+    ],
     "name:mkd_x_preferred":[
         "\u0413\u0432\u0430\u0458\u0430\u043d\u0430"
     ],
     "name:mlg_x_preferred":[
         "Guyana"
     ],
+    "name:mlg_x_variant":[
+        "Goiana"
+    ],
     "name:mlt_x_preferred":[
         "Gujana"
+    ],
+    "name:mlt_x_variant":[
+        "Guyana"
+    ],
+    "name:mni_x_preferred":[
+        "\uabd2\uabe8\uabcc\uabe5\uabc5\uabe5"
     ],
     "name:mon_x_preferred":[
         "\u0413\u0430\u0439\u0430\u043d\u0430"
@@ -652,6 +700,9 @@
     "name:san_x_preferred":[
         "\u0917\u092f\u093e\u0928\u093e"
     ],
+    "name:sat_x_preferred":[
+        "\u1c5c\u1c5f\u1c6d\u1c5f\u1c71\u1c5f"
+    ],
     "name:scn_x_preferred":[
         "Gujana"
     ],
@@ -660,6 +711,9 @@
     ],
     "name:sgs_x_preferred":[
         "Gajana"
+    ],
+    "name:shn_x_preferred":[
+        "\u1019\u102d\u1030\u1004\u103a\u1038\u1075\u1062\u1086\u1087\u101a\u1083\u1038\u107c\u1083\u1087"
     ],
     "name:sin_x_preferred":[
         "\u0d9c\u0dba\u0db1\u0dcf\u0dc0"
@@ -677,7 +731,13 @@
     "name:sme_x_preferred":[
         "Guyana"
     ],
+    "name:smn_x_preferred":[
+        "Guyana"
+    ],
     "name:smo_x_preferred":[
+        "Guyana"
+    ],
+    "name:sms_x_preferred":[
         "Guyana"
     ],
     "name:sna_x_preferred":[
@@ -737,6 +797,9 @@
     "name:tat_x_preferred":[
         "\u0413\u0430\u0439\u0430\u043d\u0430"
     ],
+    "name:tay_x_preferred":[
+        "Guyana"
+    ],
     "name:tel_x_preferred":[
         "\u0c17\u0c2f\u0c3e\u0c28\u0c3e"
     ],
@@ -759,14 +822,23 @@
     "name:tir_x_preferred":[
         "\u1309\u12eb\u1293"
     ],
+    "name:tok_x_preferred":[
+        "ma Kijana"
+    ],
     "name:ton_x_preferred":[
         "Kuiana"
     ],
     "name:tpi_x_preferred":[
         "Giana"
     ],
+    "name:trv_x_preferred":[
+        "Guyana"
+    ],
     "name:tuk_x_preferred":[
         "Ga\u00fdana"
+    ],
+    "name:tum_x_preferred":[
+        "Guyana"
     ],
     "name:tur_x_preferred":[
         "Guyana"
@@ -808,6 +880,9 @@
     ],
     "name:vie_x_variant":[
         "Guy-a-na"
+    ],
+    "name:vls_x_preferred":[
+        "Guyana"
     ],
     "name:vol_x_preferred":[
         "Gvay\u00e4n"
@@ -1100,7 +1175,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1618362109,
+    "wof:lastmodified":1690930161,
     "wof:name":"Guyana",
     "wof:parent_id":102191577,
     "wof:placetype":"country",

--- a/data/856/717/37/85671737.geojson
+++ b/data/856/717/37/85671737.geojson
@@ -69,6 +69,9 @@
     "name:hin_x_preferred":[
         "\u0908\u0938\u094d\u091f \u092c\u0947\u0930\u094d\u092c\u093f\u0938-\u0915\u094b\u0930\u0947\u0902\u091f\u0940\u0928"
     ],
+    "name:hye_x_preferred":[
+        "\u0531\u0580\u0587\u0565\u056c\u0575\u0561\u0576 \u0532\u0565\u0580\u0562\u056b\u057d-\u053f\u0578\u0580\u0565\u0576\u057f\u056b\u0576"
+    ],
     "name:ind_x_preferred":[
         "Berbice-Corentyne Timur"
     ],
@@ -107,6 +110,9 @@
     ],
     "name:por_x_preferred":[
         "Berbice Oriental-Corentyne"
+    ],
+    "name:ron_x_preferred":[
+        "East Berbice-Corentyne"
     ],
     "name:rus_x_preferred":[
         "\u0418\u0441\u0442-\u0411\u0435\u0440\u0431\u0438\u0441-\u041a\u043e\u0440\u0435\u043d\u0442\u0430\u0439\u043d"
@@ -269,7 +275,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636494755,
+    "wof:lastmodified":1690930164,
     "wof:name":"Mahaica-Berbice",
     "wof:parent_id":85632397,
     "wof:placetype":"region",

--- a/data/856/717/39/85671739.geojson
+++ b/data/856/717/39/85671739.geojson
@@ -80,6 +80,9 @@
     "name:hun_x_preferred":[
         "Potaro-Siparuni"
     ],
+    "name:hye_x_preferred":[
+        "\u054a\u0578\u057f\u0561\u0580\u0578-\u054d\u056b\u0583\u0561\u0580\u0578\u0582\u0576\u056b"
+    ],
     "name:ind_x_preferred":[
         "Potaro-Siparuni"
     ],
@@ -91,6 +94,9 @@
     ],
     "name:kan_x_preferred":[
         "\u0caa\u0ccb\u0c9f\u0ccb\u0cb0\u0ccb-\u0cb8\u0cbf\u0caa\u0cb0\u0cc1\u0ca8\u0cbf"
+    ],
+    "name:kaz_x_preferred":[
+        "\u041f\u043e\u0442\u0430\u0440\u043e-\u0421\u0438\u043f\u0430\u0440\u0443\u043d\u0438"
     ],
     "name:kor_x_preferred":[
         "\ud3ec\ud0c0\ub85c\uc2dc\ud30c\ub8e8\ub2c8 \uc9c0\ubc29"
@@ -110,6 +116,9 @@
     "name:msa_x_preferred":[
         "Potaro-Siparuni"
     ],
+    "name:nan_x_preferred":[
+        "Potaro-Siparuni T\u014da-khu"
+    ],
     "name:nld_x_preferred":[
         "Potaro-Siparuni"
     ],
@@ -126,6 +135,10 @@
         "Potaro\u2013Siparuni"
     ],
     "name:por_x_variant":[
+        "Potaro-Siparuni",
+        "Potaro-Sipar\u00fani"
+    ],
+    "name:ron_x_preferred":[
         "Potaro-Siparuni"
     ],
     "name:rus_x_preferred":[
@@ -294,7 +307,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636494755,
+    "wof:lastmodified":1690930164,
     "wof:name":"Potaro-Siparuni",
     "wof:parent_id":85632397,
     "wof:placetype":"region",

--- a/data/856/717/43/85671743.geojson
+++ b/data/856/717/43/85671743.geojson
@@ -35,6 +35,9 @@
     "name:ben_x_preferred":[
         "\u0986\u09aa\u09be\u09b0 \u09a1\u09c7\u09ae\u09be\u09b0\u09be\u09b0\u09be-\u09ac\u09be\u09b0\u09ac\u09bf\u099a"
     ],
+    "name:cat_x_preferred":[
+        "Upper Demerara-Berbice"
+    ],
     "name:ceb_x_preferred":[
         "Upper Demerara-Berbice Region"
     ],
@@ -46,6 +49,9 @@
     ],
     "name:ell_x_preferred":[
         "\u0386\u03c0\u03b5\u03c1 \u039d\u03c4\u03b5\u03bc\u03b5\u03c1\u03ac\u03c1\u03b1-\u039c\u03c0\u03b5\u03c1\u03bc\u03c0\u03af\u03ba\u03b5"
+    ],
+    "name:ell_x_variant":[
+        "\u0386\u03bd\u03c9 \u039d\u03c4\u03b5\u03bc\u03b5\u03c1\u03ac\u03c1\u03b1-\u039c\u03c0\u03ad\u03c1\u03bc\u03c0\u03b9\u03c2"
     ],
     "name:eng_x_preferred":[
         "Upper Demerara-Berbice"
@@ -74,6 +80,9 @@
     "name:hun_x_preferred":[
         "Upper Takutu-Upper Essequibo"
     ],
+    "name:hye_x_preferred":[
+        "\u054e\u0565\u0580\u056b\u0576 \u0534\u0565\u0574\u0565\u0580\u0561\u0580\u0561-\u0532\u0565\u0580\u0562\u056b\u0579\u0565"
+    ],
     "name:ind_x_preferred":[
         "Demerara Hulu-Berbice"
     ],
@@ -85,6 +94,9 @@
     ],
     "name:kan_x_preferred":[
         "\u0c85\u0caa\u0ccd\u0caa\u0cb0\u0ccd \u0ca1\u0cc6\u0cae\u0cc6\u0cb0\u0cbe-\u0cac\u0cb0\u0ccd\u0cac\u0cbf\u0cb8\u0ccd"
+    ],
+    "name:kaz_x_preferred":[
+        "\u0416\u043e\u0493\u0430\u0440\u0493\u044b \u0414\u0435\u043c\u0435\u0440\u0430\u0440\u0430-\u0411\u0435\u0440\u0431\u0438\u0441"
     ],
     "name:kor_x_preferred":[
         "\uc5b4\ud37c\ub370\uba54\ub77c\ub77c\ubc84\ube44\uc2a4\uc8fc"
@@ -101,6 +113,9 @@
     "name:msa_x_preferred":[
         "Upper Demerara-Berbice"
     ],
+    "name:nan_x_preferred":[
+        "T\u00e9ng Demerara-Berbice T\u014da-khu"
+    ],
     "name:nld_x_preferred":[
         "Upper Demerara-Berbice"
     ],
@@ -112,6 +127,9 @@
     ],
     "name:por_x_preferred":[
         "Alto Demerara-Berbice"
+    ],
+    "name:ron_x_preferred":[
+        "Upper Demerara-Berbice"
     ],
     "name:rus_x_preferred":[
         "\u0410\u043f\u043f\u0435\u0440-\u0414\u0435\u043c\u0435\u0440\u0430\u0440\u0430-\u0411\u0435\u0440\u0431\u0438\u0441"
@@ -276,7 +294,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636494754,
+    "wof:lastmodified":1690930164,
     "wof:name":"Upper Takutu-Upper Essequibo",
     "wof:parent_id":85632397,
     "wof:placetype":"region",

--- a/data/856/717/45/85671745.geojson
+++ b/data/856/717/45/85671745.geojson
@@ -32,6 +32,9 @@
     "name:ben_x_preferred":[
         "\u0986\u09aa\u09be\u09b0 \u099f\u09be\u0995\u09c1\u099f\u09c1-\u0986\u09aa\u09be\u09b0 \u098f\u09b8\u09c7\u0995\u09c1\u0987\u09ac\u09cb"
     ],
+    "name:cat_x_preferred":[
+        "Alt Takutu-Alto Essequibo"
+    ],
     "name:ceb_x_preferred":[
         "Upper Takutu-Upper Essequibo Region"
     ],
@@ -71,6 +74,9 @@
     "name:hun_x_preferred":[
         "Upper Demerara-Berbice"
     ],
+    "name:hye_x_preferred":[
+        "\u054e\u0565\u0580\u056b\u0576 \u054f\u0561\u056f\u0578\u0582\u057f\u0578\u0582-\u054e\u0565\u0580\u056b\u0576 \u0537\u057d\u0565\u056f\u056b\u0562\u0578"
+    ],
     "name:ind_x_preferred":[
         "Takutu Hulu-Essequibo Hulu"
     ],
@@ -82,6 +88,9 @@
     ],
     "name:kan_x_preferred":[
         "\u0c85\u0caa\u0ccd\u0caa\u0cb0\u0ccd \u0c9f\u0c95\u0cc1\u0ca4\u0cc1-\u0c85\u0caa\u0ccd\u0caa\u0cb0\u0ccd \u0c8e\u0cb8\u0ccd\u0cb8\u0cbf\u0cb8\u0ccd\u0c9f\u0cbf\u0cac\u0cca"
+    ],
+    "name:kaz_x_preferred":[
+        "\u0416\u043e\u0493\u0430\u0440\u0493\u044b \u0422\u0430\u043a\u0443\u0442\u0443-\u0416\u043e\u0493\u0430\u0440\u0493\u044b \u042d\u0441\u0441\u0435\u043a\u0438\u0431\u043e"
     ],
     "name:kor_x_preferred":[
         "\uc5b4\ud37c\ud0c0\ucfe0\ud22c\uc5b4\ud37c\uc5d0\uc138\ud0a4\ubcf4\uc8fc"
@@ -109,6 +118,12 @@
     ],
     "name:por_x_preferred":[
         "Alto Takutu-Alto Essequibo"
+    ],
+    "name:por_x_variant":[
+        "Alto Tacutu-Alto Essequibo"
+    ],
+    "name:ron_x_preferred":[
+        "Upper Takutu-Upper Essequibo"
     ],
     "name:rus_x_preferred":[
         "\u0410\u043f\u043f\u0435\u0440-\u0422\u0430\u043a\u0443\u0442\u0443-\u0410\u043f\u043f\u0435\u0440-\u042d\u0441\u0441\u0435\u043a\u0438\u0431\u043e"
@@ -273,7 +288,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636494754,
+    "wof:lastmodified":1690930163,
     "wof:name":"Upper Demerara-Berbice",
     "wof:parent_id":85632397,
     "wof:placetype":"region",

--- a/data/856/717/51/85671751.geojson
+++ b/data/856/717/51/85671751.geojson
@@ -32,6 +32,9 @@
     "name:ara_x_preferred":[
         "\u0628\u0627\u0631\u064a\u0645\u0627 - \u0648\u064a\u0646\u064a"
     ],
+    "name:bel_x_preferred":[
+        "\u0411\u0430\u0440\u044b\u043c\u0430-\u0423\u0430\u0439\u043d\u0456"
+    ],
     "name:ben_x_preferred":[
         "\u09ac\u09be\u09b0\u09bf\u09ae\u09be-\u0993\u09af\u09bc\u09be\u0987\u09a8\u09bf"
     ],
@@ -80,6 +83,9 @@
     "name:hun_x_preferred":[
         "Barima-Waini"
     ],
+    "name:hye_x_preferred":[
+        "\u0532\u0561\u0580\u056b\u0574\u0561-\u054e\u0561\u0575\u0576\u056b"
+    ],
     "name:ind_x_preferred":[
         "Barima-Waini"
     ],
@@ -91,6 +97,9 @@
     ],
     "name:kan_x_preferred":[
         "\u0cac\u0cb0\u0cbf\u0cae\u0cbe-\u0cb5\u0cc8\u0ca8\u0cbf"
+    ],
+    "name:kaz_x_preferred":[
+        "\u0411\u0430\u0440\u0438\u043c\u0430-\u0423\u0430\u0439\u043d\u0438"
     ],
     "name:kor_x_preferred":[
         "\ubc14\ub9ac\ub9c8\uc640\uc774\ub2c8 \uc9c0\ubc29"
@@ -109,6 +118,9 @@
     ],
     "name:msa_x_preferred":[
         "Barima-Waini"
+    ],
+    "name:nan_x_preferred":[
+        "Barima-Waini T\u014da-khu"
     ],
     "name:nld_x_preferred":[
         "Barima-Waini"
@@ -130,6 +142,9 @@
     ],
     "name:pus_x_preferred":[
         "\u0628\u0627\u0631\u06cc\u0645\u0627 \u0648\u0627\u06cc\u0646\u06cc"
+    ],
+    "name:ron_x_preferred":[
+        "Barima-Waini"
     ],
     "name:rus_x_preferred":[
         "\u0411\u0430\u0440\u0438\u043c\u0430-\u0423\u0430\u0439\u043d\u0438"
@@ -297,7 +312,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636494753,
+    "wof:lastmodified":1690930162,
     "wof:name":"Barima-Waini",
     "wof:parent_id":85632397,
     "wof:placetype":"region",

--- a/data/856/717/53/85671753.geojson
+++ b/data/856/717/53/85671753.geojson
@@ -77,6 +77,9 @@
     "name:hun_x_preferred":[
         "Pomeroon-Supenaam"
     ],
+    "name:hye_x_preferred":[
+        "\u053f\u0578\u0582\u0575\u0578\u0582\u0576\u056b-\u0544\u0561\u0566\u0561\u0580\u0578\u0582\u0576\u056b"
+    ],
     "name:ind_x_preferred":[
         "Cuyuni-Mazaruni"
     ],
@@ -88,6 +91,9 @@
     ],
     "name:kan_x_preferred":[
         "\u0c95\u0cc1\u0caf\u0cc1\u0ca8\u0cbf-\u0cae\u0c9d\u0cb0\u0cc1\u0ca8\u0cbf"
+    ],
+    "name:kaz_x_preferred":[
+        "\u041a\u0443\u044e\u043d\u0438-\u041c\u0430\u0437\u0430\u0440\u0443\u043d\u0438"
     ],
     "name:kor_x_preferred":[
         "\ucfe0\uc720\ub2c8\ub9c8\uc790\ub8e8\ub2c8\uc8fc"
@@ -104,6 +110,9 @@
     "name:msa_x_preferred":[
         "Cuyuni-Mazaruni"
     ],
+    "name:nan_x_preferred":[
+        "Cuyuni-Mazaruni T\u014da-khu"
+    ],
     "name:nld_x_preferred":[
         "Cuyuni-Mazaruni"
     ],
@@ -114,6 +123,9 @@
         "Cuyuni-Mazaruni"
     ],
     "name:por_x_preferred":[
+        "Cuyuni-Mazaruni"
+    ],
+    "name:ron_x_preferred":[
         "Cuyuni-Mazaruni"
     ],
     "name:rus_x_preferred":[
@@ -279,7 +291,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636494754,
+    "wof:lastmodified":1690930164,
     "wof:name":"Pomeroon-Supenaam",
     "wof:parent_id":85632397,
     "wof:placetype":"region",

--- a/data/856/717/57/85671757.geojson
+++ b/data/856/717/57/85671757.geojson
@@ -80,6 +80,9 @@
     "name:hun_x_preferred":[
         "East Berbice-Corentyne"
     ],
+    "name:hye_x_preferred":[
+        "\u0534\u0565\u0574\u0565\u0580\u0561\u0580\u0561-\u0544\u0561\u056d\u0561\u056b\u056f\u0561"
+    ],
     "name:ind_x_preferred":[
         "Demerara-Mahaica"
     ],
@@ -91,6 +94,12 @@
     ],
     "name:kan_x_preferred":[
         "\u0ca1\u0cc6\u0cae\u0cc6\u0cb0\u0cb0\u0cbe-\u0cae\u0cb9\u0cbe\u0c95\u0cbe"
+    ],
+    "name:kat_x_preferred":[
+        "\u10d3\u10d4\u10db\u10d4\u10e0\u10d0\u10e0\u10d0-\u10db\u10d0\u10f0\u10d0\u10d8\u10d9\u10d0"
+    ],
+    "name:kaz_x_preferred":[
+        "\u0414\u0435\u043c\u0435\u0440\u0430\u0440\u0430-\u041c\u0430\u0445\u0430\u0439\u043a\u0430"
     ],
     "name:kor_x_preferred":[
         "\ub370\uba54\ub77c\ub77c\ub9c8\ud558\uc774\uce74\uc8fc"
@@ -107,6 +116,9 @@
     "name:msa_x_preferred":[
         "Demerara-Mahaica"
     ],
+    "name:nan_x_preferred":[
+        "Demerara-Mahaica T\u014da-khu"
+    ],
     "name:nld_x_preferred":[
         "Demerara-Mahaica"
     ],
@@ -117,6 +129,9 @@
         "Demerara-Mahaica"
     ],
     "name:por_x_preferred":[
+        "Demerara-Mahaica"
+    ],
+    "name:ron_x_preferred":[
         "Demerara-Mahaica"
     ],
     "name:rus_x_preferred":[
@@ -282,7 +297,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636494753,
+    "wof:lastmodified":1690930162,
     "wof:name":"East Berbice-Corentyne",
     "wof:parent_id":-1,
     "wof:placetype":"region",

--- a/data/856/717/67/85671767.geojson
+++ b/data/856/717/67/85671767.geojson
@@ -68,6 +68,9 @@
     "name:hun_x_preferred":[
         "Essequibo Islands-West Demerara"
     ],
+    "name:hye_x_preferred":[
+        "\u0544\u0561\u056d\u0561\u0575\u056f\u0561-\u0532\u0580\u0562\u056b\u0581\u0565"
+    ],
     "name:ind_x_preferred":[
         "Mahaica-Berbice"
     ],
@@ -77,11 +80,17 @@
     "name:jpn_x_preferred":[
         "\u30de\u30cf\u30a4\u30ab\uff1d\u30d9\u30eb\u30d3\u30bb\u5dde"
     ],
+    "name:kaz_x_preferred":[
+        "\u041c\u0430\u0445\u0430\u0439\u043a\u0430-\u0411\u0435\u0440\u0431\u0438\u0441"
+    ],
     "name:kor_x_preferred":[
         "\ub9c8\ud558\uc774\uce74\ubc84\ube44\uc2a4\uc8fc"
     ],
     "name:lit_x_preferred":[
         "Mahaika-Berbisas"
+    ],
+    "name:nan_x_preferred":[
+        "Mahaica-Berbice T\u014da-khu"
     ],
     "name:nld_x_preferred":[
         "Mahaica-Berbice"
@@ -93,6 +102,9 @@
         "Mahaica-Berbice"
     ],
     "name:por_x_preferred":[
+        "Mahaica-Berbice"
+    ],
+    "name:ron_x_preferred":[
         "Mahaica-Berbice"
     ],
     "name:rus_x_preferred":[
@@ -246,7 +258,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636494753,
+    "wof:lastmodified":1690930163,
     "wof:name":"Essequibo Islands-West Demerara",
     "wof:parent_id":85632397,
     "wof:placetype":"region",

--- a/data/856/717/73/85671773.geojson
+++ b/data/856/717/73/85671773.geojson
@@ -77,6 +77,9 @@
     "name:hun_x_preferred":[
         "Cuyuni-Mazaruni"
     ],
+    "name:hye_x_preferred":[
+        "\u054a\u0578\u0574\u0565\u0580\u0578\u0582\u0576-\u054d\u0578\u0582\u057a\u0565\u0576\u0561\u0561\u0574"
+    ],
     "name:ind_x_preferred":[
         "Pomeroon-Supenaam"
     ],
@@ -88,6 +91,9 @@
     ],
     "name:kan_x_preferred":[
         "\u0caa\u0ccb\u0cae\u0cb0\u0cc2\u0ca8\u0ccd-\u0cb8\u0cc1\u0caa\u0cc0\u0ca8\u0cbe\u0cae\u0ccd"
+    ],
+    "name:kaz_x_preferred":[
+        "\u041f\u043e\u043c\u0435\u0440\u0443\u043d-\u0421\u0443\u043f\u0435\u043d\u0430\u0430\u043c"
     ],
     "name:kor_x_preferred":[
         "\ud3ec\uba54\ub8ec\uc218\ud398\ub0a8\uc8fc"
@@ -104,6 +110,9 @@
     "name:msa_x_preferred":[
         "Pomeroon-Supenaam"
     ],
+    "name:nan_x_preferred":[
+        "Pomeroon-Supenaam T\u014da-khu"
+    ],
     "name:nld_x_preferred":[
         "Pomeroon-Supenaam"
     ],
@@ -114,6 +123,9 @@
         "Pomeroon-Supenaam"
     ],
     "name:por_x_preferred":[
+        "Pomeroon-Supenaam"
+    ],
+    "name:ron_x_preferred":[
         "Pomeroon-Supenaam"
     ],
     "name:rus_x_preferred":[
@@ -279,7 +291,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636494754,
+    "wof:lastmodified":1690930163,
     "wof:name":"Cuyuni-Mazaruni",
     "wof:parent_id":85632397,
     "wof:placetype":"region",

--- a/data/857/648/41/85764841.geojson
+++ b/data/857/648/41/85764841.geojson
@@ -37,11 +37,23 @@
     "name:jpn_x_preferred":[
         "\u30d6\u30eb\u30c0"
     ],
+    "name:mar_x_preferred":[
+        "\u092c\u093e\u0909\u0930\u094d\u0921\u093e"
+    ],
+    "name:pnb_x_preferred":[
+        "\u0628\u0624\u0631\u062f\u0627"
+    ],
     "name:spa_x_preferred":[
         "Bourda"
     ],
     "name:urd_x_preferred":[
         "\u0628\u0624\u0631\u062f\u0627"
+    ],
+    "name:vie_x_preferred":[
+        "Bourda"
+    ],
+    "name:zho_x_preferred":[
+        "\u5e03\u723e\u9054"
     ],
     "qs:gn_adm0_cc":"GY",
     "qs:gn_id":0,
@@ -100,7 +112,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1582313373,
+    "wof:lastmodified":1690930160,
     "wof:name":"Bourda",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/435/769/890435769.geojson
+++ b/data/890/435/769/890435769.geojson
@@ -37,6 +37,9 @@
     "name:pol_x_preferred":[
         "Mahaicony"
     ],
+    "name:spa_x_preferred":[
+        "Mahaicony"
+    ],
     "name:swe_x_preferred":[
         "Mahaicony Village"
     ],
@@ -81,7 +84,7 @@
         }
     ],
     "wof:id":890435769,
-    "wof:lastmodified":1566644395,
+    "wof:lastmodified":1690930167,
     "wof:name":"Mahaicony Village",
     "wof:parent_id":1091681309,
     "wof:placetype":"locality",

--- a/data/890/438/257/890438257.geojson
+++ b/data/890/438/257/890438257.geojson
@@ -64,6 +64,9 @@
     "name:hin_x_preferred":[
         "\u0921\u0947\u092e\u0930\u093e\u0930\u093e-\u092e\u0939\u093e\u0907\u0915\u093e"
     ],
+    "name:hye_x_preferred":[
+        "\u0534\u0565\u0574\u0565\u0580\u0561\u0580\u0561-\u0544\u0561\u056d\u0561\u056b\u056f\u0561"
+    ],
     "name:ind_x_preferred":[
         "Demerara-Mahaica"
     ],
@@ -75,6 +78,12 @@
     ],
     "name:kan_x_preferred":[
         "\u0ca1\u0cc6\u0cae\u0cc6\u0cb0\u0cb0\u0cbe-\u0cae\u0cb9\u0cbe\u0c95\u0cbe"
+    ],
+    "name:kat_x_preferred":[
+        "\u10d3\u10d4\u10db\u10d4\u10e0\u10d0\u10e0\u10d0-\u10db\u10d0\u10f0\u10d0\u10d8\u10d9\u10d0"
+    ],
+    "name:kaz_x_preferred":[
+        "\u0414\u0435\u043c\u0435\u0440\u0430\u0440\u0430-\u041c\u0430\u0445\u0430\u0439\u043a\u0430"
     ],
     "name:kor_x_preferred":[
         "\ub370\uba54\ub77c\ub77c\ub9c8\ud558\uc774\uce74\uc8fc"
@@ -91,6 +100,9 @@
     "name:msa_x_preferred":[
         "Demerara-Mahaica"
     ],
+    "name:nan_x_preferred":[
+        "Demerara-Mahaica T\u014da-khu"
+    ],
     "name:nld_x_preferred":[
         "Demerara-Mahaica"
     ],
@@ -101,6 +113,9 @@
         "Demerara-Mahaica"
     ],
     "name:por_x_preferred":[
+        "Demerara-Mahaica"
+    ],
+    "name:ron_x_preferred":[
         "Demerara-Mahaica"
     ],
     "name:rus_x_preferred":[
@@ -183,7 +198,7 @@
         }
     ],
     "wof:id":890438257,
-    "wof:lastmodified":1566644394,
+    "wof:lastmodified":1690930166,
     "wof:name":"Mahaica Village",
     "wof:parent_id":1091681309,
     "wof:placetype":"locality",

--- a/data/890/438/763/890438763.geojson
+++ b/data/890/438/763/890438763.geojson
@@ -25,8 +25,17 @@
     "name:ara_x_variant":[
         "\u0646\u064a\u0648 \u0623\u0645\u0633\u062a\u0631\u062f\u0627\u0645"
     ],
+    "name:arz_x_preferred":[
+        "\u0646\u064a\u0648 \u0627\u0645\u0633\u062a\u0631\u062f\u0627\u0645"
+    ],
+    "name:ast_x_preferred":[
+        "New Amsterdam"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041d\u044c\u044e-\u0410\u043c\u0441\u0442\u044d\u0440\u0434\u0430\u043c"
+    ],
+    "name:bel_x_variant":[
+        "\u041d\u044c\u044e-\u0410\u043c\u0441\u0442\u044d\u0440\u0434\u0430\u043c"
     ],
     "name:ben_x_preferred":[
         "\u09a8\u09bf\u0989 \u0986\u09ae\u09b8\u09cd\u099f\u09be\u09b0\u09a1\u09be\u09ae"
@@ -84,6 +93,9 @@
     ],
     "name:kan_x_preferred":[
         "\u0ca8\u0ccd\u0caf\u0cc2 \u0c86\u0cae\u0ccd\u0cb8\u0ccd\u0c9f\u0cb0\u0ccd\u0ca1\u0ccd\u0caf\u0cbe\u0cae\u0ccd"
+    ],
+    "name:kaz_x_preferred":[
+        "\u041d\u044c\u044e-\u0410\u043c\u0441\u0442\u0435\u0440\u0434\u0430\u043c"
     ],
     "name:kor_x_preferred":[
         "\ub274\uc554\uc2a4\ud14c\ub974\ub2f4"
@@ -278,7 +290,7 @@
         }
     ],
     "wof:id":890438763,
-    "wof:lastmodified":1636494759,
+    "wof:lastmodified":1690930166,
     "wof:name":"New Amsterdam",
     "wof:parent_id":1091685479,
     "wof:placetype":"locality",

--- a/data/890/438/767/890438767.geojson
+++ b/data/890/438/767/890438767.geojson
@@ -25,11 +25,20 @@
     "name:ceb_x_preferred":[
         "Skeldon"
     ],
+    "name:deu_x_preferred":[
+        "Skeldon"
+    ],
     "name:eng_x_preferred":[
         "Skeldon"
     ],
     "name:fra_x_preferred":[
         "Skeldon"
+    ],
+    "name:ita_x_preferred":[
+        "Skeldon"
+    ],
+    "name:kaz_x_preferred":[
+        "\u0421\u043a\u0435\u043b\u0434\u043e\u043d"
     ],
     "name:kor_x_preferred":[
         "\uc2a4\ucf08\ub358"
@@ -45,6 +54,9 @@
     ],
     "name:por_x_preferred":[
         "Skeldon"
+    ],
+    "name:rus_x_preferred":[
+        "\u0421\u043a\u0435\u043b\u0434\u043e\u043d"
     ],
     "name:swe_x_preferred":[
         "Skeldon"
@@ -82,7 +94,7 @@
         }
     ],
     "wof:id":890438767,
-    "wof:lastmodified":1566644394,
+    "wof:lastmodified":1690930166,
     "wof:name":"Skeldon",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/438/771/890438771.geojson
+++ b/data/890/438/771/890438771.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ast_x_preferred":[
+        "Rosignol"
+    ],
     "name:bul_x_preferred":[
         "\u0420\u043e\u0441\u0438\u0433\u043d\u043e\u043b"
     ],
@@ -54,6 +57,9 @@
     ],
     "name:und_x_variant":[
         "Rosignal"
+    ],
+    "name:urd_x_preferred":[
+        "\u0631\u0648\u0632\u06af\u0646\u0648\u0644"
     ],
     "name:vol_x_preferred":[
         "Rosignol"
@@ -104,7 +110,7 @@
         }
     ],
     "wof:id":890438771,
-    "wof:lastmodified":1566644394,
+    "wof:lastmodified":1690930166,
     "wof:name":"Rosignol",
     "wof:parent_id":1091683545,
     "wof:placetype":"locality",

--- a/data/890/438/773/890438773.geojson
+++ b/data/890/438/773/890438773.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ast_x_preferred":[
+        "Parika"
+    ],
     "name:ceb_x_preferred":[
         "Parika"
     ],
@@ -30,6 +33,9 @@
     ],
     "name:fra_x_preferred":[
         "Parika"
+    ],
+    "name:kaz_x_preferred":[
+        "\u041f\u0430\u0440\u0438\u043a\u0430"
     ],
     "name:kor_x_preferred":[
         "\ud30c\ub9ac\uce74"
@@ -45,6 +51,9 @@
     ],
     "name:por_x_preferred":[
         "Parika"
+    ],
+    "name:rus_x_preferred":[
+        "\u041f\u0430\u0440\u0438\u043a\u0430"
     ],
     "name:spa_x_preferred":[
         "Parika"
@@ -90,7 +99,7 @@
         }
     ],
     "wof:id":890438773,
-    "wof:lastmodified":1566644394,
+    "wof:lastmodified":1690930166,
     "wof:name":"Parika",
     "wof:parent_id":1091682611,
     "wof:placetype":"locality",

--- a/data/890/444/585/890444585.geojson
+++ b/data/890/444/585/890444585.geojson
@@ -36,14 +36,23 @@
     "name:ara_x_variant":[
         "\u062c\u0648\u0631\u062c \u062a\u0627\u0648\u0646"
     ],
+    "name:ary_x_preferred":[
+        "\u062c\u0648\u0631\u062c\u0637\u0627\u0648\u0646"
+    ],
     "name:arz_x_preferred":[
         "\u062c\u0648\u0631\u062c \u062a\u0627\u0648\u0646"
     ],
     "name:ast_x_preferred":[
         "Georgetown"
     ],
+    "name:avk_x_preferred":[
+        "Georgetown"
+    ],
     "name:aze_x_preferred":[
         "Corctaun"
+    ],
+    "name:ban_x_preferred":[
+        "Georgetown"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0414\u0436\u043e\u0440\u0434\u0436\u0442\u0430\u045e\u043d"
@@ -181,6 +190,9 @@
     "name:ile_x_preferred":[
         "Georgetown"
     ],
+    "name:ina_x_preferred":[
+        "Georgetown"
+    ],
     "name:ind_x_preferred":[
         "Georgetown"
     ],
@@ -244,6 +256,9 @@
     "name:msa_x_preferred":[
         "Georgetown"
     ],
+    "name:mzn_x_preferred":[
+        "\u062c\u0648\u0631\u062c \u062a\u0627\u0624\u0646"
+    ],
     "name:nah_x_preferred":[
         "Georgetown"
     ],
@@ -255,6 +270,9 @@
     ],
     "name:nno_x_preferred":[
         "Georgetown i Guyana"
+    ],
+    "name:nno_x_variant":[
+        "Georgetown"
     ],
     "name:nob_x_preferred":[
         "Georgetown"
@@ -286,6 +304,9 @@
     "name:pms_x_preferred":[
         "Georgetown"
     ],
+    "name:pnb_x_preferred":[
+        "\u062c\u0627\u0631\u062c \u0679\u0627\u0624\u0646"
+    ],
     "name:pol_x_preferred":[
         "Georgetown"
     ],
@@ -294,6 +315,9 @@
     ],
     "name:por_x_preferred":[
         "Georgetown"
+    ],
+    "name:pus_x_preferred":[
+        "\u062c\u0648\u0631\u062c \u067c\u0627\u0648\u0646"
     ],
     "name:que_x_preferred":[
         "Georgetown"
@@ -306,6 +330,9 @@
     ],
     "name:rus_x_preferred":[
         "\u0414\u0436\u043e\u0440\u0434\u0436\u0442\u0430\u0443\u043d"
+    ],
+    "name:sat_x_preferred":[
+        "\u1c61\u1c5a\u1c68\u1c61\u1c7d\u1c74\u1c5f\u1c63\u1c69\u1c71"
     ],
     "name:sco_x_preferred":[
         "Georgetown"
@@ -334,6 +361,9 @@
     "name:sqi_x_preferred":[
         "Georgetown"
     ],
+    "name:srd_x_preferred":[
+        "Georgetown"
+    ],
     "name:srp_x_preferred":[
         "\u040f\u043e\u0440\u045f\u0442\u0430\u0443\u043d"
     ],
@@ -351,6 +381,9 @@
     ],
     "name:tat_x_preferred":[
         "\u0496\u043e\u0440\u0497\u0442\u0430\u0443\u043d"
+    ],
+    "name:tat_x_variant":[
+        "\u0414\u0436\u043e\u0440\u0434\u0436\u0442\u0430\u0443\u043d"
     ],
     "name:tel_x_preferred":[
         "\u0c1c\u0c3e\u0c30\u0c4d\u0c1c\u0c4d \u0c1f\u0c4c\u0c28\u0c4d"
@@ -561,7 +594,7 @@
         }
     ],
     "wof:id":890444585,
-    "wof:lastmodified":1636494759,
+    "wof:lastmodified":1690930167,
     "wof:name":"Georgetown",
     "wof:parent_id":1091683403,
     "wof:placetype":"locality",

--- a/data/890/444/587/890444587.geojson
+++ b/data/890/444/587/890444587.geojson
@@ -22,6 +22,12 @@
     "name:ara_x_preferred":[
         "\u0628\u0627\u0631\u062a\u064a\u0633\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0627\u0631\u062a\u064a\u0633\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "Bartica"
+    ],
     "name:ben_x_preferred":[
         "\u09ac\u09be\u09b0\u09cd\u09a4\u09bf\u0995\u09be"
     ],
@@ -60,6 +66,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30d0\u30eb\u30c6\u30a3\u30ab"
+    ],
+    "name:kaz_x_preferred":[
+        "\u0411\u0430\u0440\u0442\u0438\u043a\u0430"
     ],
     "name:kor_x_preferred":[
         "\ubc14\ub974\ud2f0\uce74"
@@ -230,7 +239,7 @@
         }
     ],
     "wof:id":890444587,
-    "wof:lastmodified":1636494759,
+    "wof:lastmodified":1690930167,
     "wof:name":"Bartica",
     "wof:parent_id":85671753,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.