### PR TITLE
gy concordances, placetype local, and more

### DIFF
--- a/data/109/168/114/1/1091681141.geojson
+++ b/data/109/168/114/1/1091681141.geojson
@@ -55,6 +55,7 @@
     "wof:concordances":{
         "hasc:id":"GY.BA.UN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473878951,
     "wof:geomhash":"2bdaedb90232cc47f074644f0cd605a6",
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1091681141,
-    "wof:lastmodified":1694498076,
+    "wof:lastmodified":1695886416,
     "wof:name":"Unorganized",
     "wof:parent_id":85671751,
     "wof:placetype":"county",

--- a/data/109/168/114/7/1091681147.geojson
+++ b/data/109/168/114/7/1091681147.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.449722,
-    "geom:area_square_m":5508150615.603601,
+    "geom:area_square_m":5508150221.143476,
     "geom:bbox":"-60.369558,7.428784,-59.339937,8.525899",
     "geom:latitude":7.896569,
     "geom:longitude":-59.809549,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.BA.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473878953,
-    "wof:geomhash":"cbd09d5c904d97b8c5315da22f618037",
+    "wof:geomhash":"8bfa694b3f7eef72af79e1f0dea77b18",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091681147,
-    "wof:lastmodified":1627522163,
+    "wof:lastmodified":1695886631,
     "wof:name":"Barima/Amakura",
     "wof:parent_id":85671751,
     "wof:placetype":"county",

--- a/data/109/168/114/9/1091681149.geojson
+++ b/data/109/168/114/9/1091681149.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.437356,
-    "geom:area_square_m":5358985833.987188,
+    "geom:area_square_m":5358987073.590242,
     "geom:bbox":"-59.809639,7.26293,-58.791649,8.40875",
     "geom:latitude":7.715035,
     "geom:longitude":-59.297406,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.BA.WA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473878954,
-    "wof:geomhash":"7a15f24ef89dec2dc45874b16b46e380",
+    "wof:geomhash":"7f618c3cfd26160426d8ec8a3d017fa2",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091681149,
-    "wof:lastmodified":1627522163,
+    "wof:lastmodified":1695886631,
     "wof:name":"Waini",
     "wof:parent_id":85671751,
     "wof:placetype":"county",

--- a/data/109/168/115/1/1091681151.geojson
+++ b/data/109/168/115/1/1091681151.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004493,
-    "geom:area_square_m":55097077.164818,
+    "geom:area_square_m":55097068.413535,
     "geom:bbox":"-58.588831,7.335546,-58.48246,7.417459",
     "geom:latitude":7.367205,
     "geom:longitude":-58.533993,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"GY.PM.PE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473878955,
-    "wof:geomhash":"b56450b433f92653a4041b29bf5276e6",
+    "wof:geomhash":"d05e8e7dced59bff5254974ef0cc7d41",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1091681151,
-    "wof:lastmodified":1627522166,
+    "wof:lastmodified":1695886634,
     "wof:name":"Paradise/Evergreen (including Somerset and Berks)",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/168/119/7/1091681197.geojson
+++ b/data/109/168/119/7/1091681197.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.188959,
-    "geom:area_square_m":2317283060.032398,
+    "geom:area_square_m":2317283362.599295,
     "geom:bbox":"-59.130136,6.979457,-58.535667,7.66806",
     "geom:latitude":7.354041,
     "geom:longitude":-58.801086,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"GY.PM.CU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473878958,
-    "wof:geomhash":"8bc7cf71b0fd5961478ced1aef2a795c",
+    "wof:geomhash":"749582872c5663ef214c5c8d6e3e4172",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1091681197,
-    "wof:lastmodified":1627522164,
+    "wof:lastmodified":1695886632,
     "wof:name":"Charity/Urasara",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/168/124/3/1091681243.geojson
+++ b/data/109/168/124/3/1091681243.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005938,
-    "geom:area_square_m":72916041.430506,
+    "geom:area_square_m":72916029.740566,
     "geom:bbox":"-58.013835,6.646985,-57.926287,6.772204",
     "geom:latitude":6.707648,
     "geom:longitude":-57.972784,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.DE.GH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473878959,
-    "wof:geomhash":"b7bdf90a725a68550c8410cc9b155a89",
+    "wof:geomhash":"12af7b1c2c9c6451e90ea14984f016a7",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091681243,
-    "wof:lastmodified":1627522164,
+    "wof:lastmodified":1695886632,
     "wof:name":"Grove/Haslington",
     "wof:parent_id":85671761,
     "wof:placetype":"county",

--- a/data/109/168/127/7/1091681277.geojson
+++ b/data/109/168/127/7/1091681277.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00646,
-    "geom:area_square_m":79228612.743334,
+    "geom:area_square_m":79228840.363533,
     "geom:bbox":"-58.559354,7.225596,-58.475834,7.340613",
     "geom:latitude":7.290275,
     "geom:longitude":-58.511025,
@@ -147,9 +147,10 @@
     "wof:concordances":{
         "hasc:id":"GY.PM.AR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473878961,
-    "wof:geomhash":"057acede72361caa42b23ad1264cea1d",
+    "wof:geomhash":"8636386c88942c6d01b755ecb038c448",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -165,7 +166,7 @@
         }
     ],
     "wof:id":1091681277,
-    "wof:lastmodified":1636494757,
+    "wof:lastmodified":1695886618,
     "wof:name":"Anna Regina",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/168/130/9/1091681309.geojson
+++ b/data/109/168/130/9/1091681309.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008402,
-    "geom:area_square_m":103192251.753716,
+    "geom:area_square_m":103192249.346266,
     "geom:bbox":"-57.92466,6.571275,-57.783182,6.711954",
     "geom:latitude":6.633887,
     "geom:longitude":-57.860064,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"GY.MA.FW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473878963,
-    "wof:geomhash":"5107aa8e4f0a0eb159529b0508c6d689",
+    "wof:geomhash":"d1b98abab5efcac129c3b5d7201e0d13",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1091681309,
-    "wof:lastmodified":1627522164,
+    "wof:lastmodified":1695886632,
     "wof:name":"Farm/Woodlands",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/168/137/1/1091681371.geojson
+++ b/data/109/168/137/1/1091681371.geojson
@@ -56,6 +56,7 @@
     "wof:concordances":{
         "hasc:id":"GY.MA.RS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473878965,
     "wof:geomhash":"c7478b40a69198fcdf23e04b2d1ba6c7",
@@ -74,7 +75,7 @@
         }
     ],
     "wof:id":1091681371,
-    "wof:lastmodified":1694498075,
+    "wof:lastmodified":1695886392,
     "wof:name":"Rising Sun/Profit",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/168/139/3/1091681393.geojson
+++ b/data/109/168/139/3/1091681393.geojson
@@ -54,6 +54,7 @@
     "wof:concordances":{
         "hasc:id":"GY.EB.NV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473878967,
     "wof:geomhash":"3527b7b7c057462a0fe187f9478e50c8",
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1091681393,
-    "wof:lastmodified":1694498074,
+    "wof:lastmodified":1695886359,
     "wof:name":"No.74 Village/No.52 Village",
     "wof:parent_id":85671757,
     "wof:placetype":"county",

--- a/data/109/168/145/3/1091681453.geojson
+++ b/data/109/168/145/3/1091681453.geojson
@@ -54,6 +54,7 @@
     "wof:concordances":{
         "hasc:id":"GY.EB.NG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473878970,
     "wof:geomhash":"5b7a56f4a8b2819bed565f1ad95b33f7",
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1091681453,
-    "wof:lastmodified":1694498074,
+    "wof:lastmodified":1695886360,
     "wof:name":"No.51 Village/Good hope",
     "wof:parent_id":85671757,
     "wof:placetype":"county",

--- a/data/109/168/147/9/1091681479.geojson
+++ b/data/109/168/147/9/1091681479.geojson
@@ -54,6 +54,7 @@
     "wof:concordances":{
         "hasc:id":"GY.EB.JM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473878972,
     "wof:geomhash":"b2aeda7691a47037eb4e149acdbbddb4",
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1091681479,
-    "wof:lastmodified":1694498073,
+    "wof:lastmodified":1695886310,
     "wof:name":"Joppa/Macedonia",
     "wof:parent_id":85671757,
     "wof:placetype":"county",

--- a/data/109/168/153/1/1091681531.geojson
+++ b/data/109/168/153/1/1091681531.geojson
@@ -54,6 +54,7 @@
     "wof:concordances":{
         "hasc:id":"GY.EB.TM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473878974,
     "wof:geomhash":"31aacc4c2e3b0364c982d9d9559306fe",
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1091681531,
-    "wof:lastmodified":1694498076,
+    "wof:lastmodified":1695886409,
     "wof:name":"Tarlogie/Maida",
     "wof:parent_id":85671757,
     "wof:placetype":"county",

--- a/data/109/168/157/5/1091681575.geojson
+++ b/data/109/168/157/5/1091681575.geojson
@@ -54,6 +54,7 @@
     "wof:concordances":{
         "hasc:id":"GY.EB.HL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473878975,
     "wof:geomhash":"0a9d6fd8073c63148f3e99142dbb8738",
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1091681575,
-    "wof:lastmodified":1694498072,
+    "wof:lastmodified":1695886301,
     "wof:name":"Hogstye/Lancaster",
     "wof:parent_id":85671757,
     "wof:placetype":"county",

--- a/data/109/168/161/1/1091681611.geojson
+++ b/data/109/168/161/1/1091681611.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005749,
-    "geom:area_square_m":70643153.846756,
+    "geom:area_square_m":70643259.412602,
     "geom:bbox":"-57.72476,6.399121,-57.615743,6.49438",
     "geom:latitude":6.444463,
     "geom:longitude":-57.670341,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"GY.MA.TS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473878977,
-    "wof:geomhash":"8828921b588a48293015461ee59b2713",
+    "wof:geomhash":"951d854996d546acc541d3eec55f5619",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1091681611,
-    "wof:lastmodified":1627522167,
+    "wof:lastmodified":1695886635,
     "wof:name":"Tempe/Seafield",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/168/165/5/1091681655.geojson
+++ b/data/109/168/165/5/1091681655.geojson
@@ -54,6 +54,7 @@
     "wof:concordances":{
         "hasc:id":"GY.EB.BN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473878978,
     "wof:geomhash":"95d4c14d79bc1fedb6da74433c4d4114",
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1091681655,
-    "wof:lastmodified":1694498070,
+    "wof:lastmodified":1695886269,
     "wof:name":"Borlam (No.37)/Kintyre",
     "wof:parent_id":85671757,
     "wof:placetype":"county",

--- a/data/109/168/170/1/1091681701.geojson
+++ b/data/109/168/170/1/1091681701.geojson
@@ -56,6 +56,7 @@
     "wof:concordances":{
         "hasc:id":"GY.UT.UN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473878980,
     "wof:geomhash":"90394683845e469074249d9c7f176e6d",
@@ -74,7 +75,7 @@
         }
     ],
     "wof:id":1091681701,
-    "wof:lastmodified":1694498077,
+    "wof:lastmodified":1695886416,
     "wof:name":"Unorganized",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/168/173/3/1091681733.geojson
+++ b/data/109/168/173/3/1091681733.geojson
@@ -55,6 +55,7 @@
     "wof:concordances":{
         "hasc:id":"GY.CU.UN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473878981,
     "wof:geomhash":"02d6dfd53e998821776fe8112dc5f5e5",
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1091681733,
-    "wof:lastmodified":1694498077,
+    "wof:lastmodified":1695886416,
     "wof:name":"Unorganized",
     "wof:parent_id":85671773,
     "wof:placetype":"county",

--- a/data/109/168/178/1/1091681781.geojson
+++ b/data/109/168/178/1/1091681781.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.177548,
-    "geom:area_square_m":2191864677.649481,
+    "geom:area_square_m":2191864187.505712,
     "geom:bbox":"-59.961336,2.965111,-59.448307,3.588228",
     "geom:latitude":3.258614,
     "geom:longitude":-59.70735,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"GY.UT.IS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473878983,
-    "wof:geomhash":"31ad29603b1a221c9301c304cce56f6d",
+    "wof:geomhash":"1dff558f1e4d95b5135c1b97250e9d8b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1091681781,
-    "wof:lastmodified":1627522164,
+    "wof:lastmodified":1695886632,
     "wof:name":"Ireng/Sawariwau (Incl. St Ignatius)",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/168/182/7/1091681827.geojson
+++ b/data/109/168/182/7/1091681827.geojson
@@ -55,6 +55,7 @@
     "wof:concordances":{
         "hasc:id":"GY.CU.UN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473878984,
     "wof:geomhash":"dc1b2bff514bb0b1278b2087b2ffd968",
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1091681827,
-    "wof:lastmodified":1694498077,
+    "wof:lastmodified":1695886416,
     "wof:name":"Unorganized",
     "wof:parent_id":85671773,
     "wof:placetype":"county",

--- a/data/109/168/187/7/1091681877.geojson
+++ b/data/109/168/187/7/1091681877.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
-    "geom:area_square_m":4330.995325,
+    "geom:area_square_m":4320.550423,
     "geom:bbox":"-60.293412,7.090937,-60.291577,7.0915",
     "geom:latitude":7.091168,
     "geom:longitude":-60.292508,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.CU.UN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473878986,
-    "wof:geomhash":"161760c711809d2965b955cc2305a6d4",
+    "wof:geomhash":"4f9ea91a78cdd11c62c25f9ba979170a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091681877,
-    "wof:lastmodified":1627522168,
+    "wof:lastmodified":1695886636,
     "wof:name":"Unorganized",
     "wof:parent_id":85671773,
     "wof:placetype":"county",

--- a/data/109/168/191/5/1091681915.geojson
+++ b/data/109/168/191/5/1091681915.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007842,
-    "geom:area_square_m":96593106.176858,
+    "geom:area_square_m":96593166.41798,
     "geom:bbox":"-59.658428,4.990251,-59.497256,5.088149",
     "geom:latitude":5.042965,
     "geom:longitude":-59.573078,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.PT.CR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473878987,
-    "wof:geomhash":"c0aa60961daabbe24c53e24adec8ab4f",
+    "wof:geomhash":"d9cb9b80823285e5b25bd54997dd87b0",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091681915,
-    "wof:lastmodified":1627522164,
+    "wof:lastmodified":1695886632,
     "wof:name":"Chenapau River",
     "wof:parent_id":85671739,
     "wof:placetype":"county",

--- a/data/109/168/196/1/1091681961.geojson
+++ b/data/109/168/196/1/1091681961.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.238132,
-    "geom:area_square_m":2922476333.903912,
+    "geom:area_square_m":2922476553.992676,
     "geom:bbox":"-59.240851,6.717724,-58.520294,7.372703",
     "geom:latitude":7.018524,
     "geom:longitude":-58.944193,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.PM.SB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473878989,
-    "wof:geomhash":"0ec3228895c238cb99bbeaaf52ace70c",
+    "wof:geomhash":"b07a2def10ded51f4023acd866eb8ab1",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091681961,
-    "wof:lastmodified":1627522166,
+    "wof:lastmodified":1695886634,
     "wof:name":"Supernaam River, Bethany and Mashabo villages",
     "wof:parent_id":85671753,
     "wof:placetype":"county",

--- a/data/109/168/200/7/1091682007.geojson
+++ b/data/109/168/200/7/1091682007.geojson
@@ -56,6 +56,7 @@
     "wof:concordances":{
         "hasc:id":"GY.PM.GH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473878990,
     "wof:geomhash":"5d49d89fd5a47eb82a1ac1c848f89b0d",
@@ -74,7 +75,7 @@
         }
     ],
     "wof:id":1091682007,
-    "wof:lastmodified":1694498072,
+    "wof:lastmodified":1695886299,
     "wof:name":"Good Hope/Pomona",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/168/204/1/1091682041.geojson
+++ b/data/109/168/204/1/1091682041.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.046481,
-    "geom:area_square_m":570261446.241897,
+    "geom:area_square_m":570260845.51763,
     "geom:bbox":"-58.698503,6.991368,-58.475639,7.374589",
     "geom:latitude":7.166796,
     "geom:longitude":-58.582236,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"GY.PM.RA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473878992,
-    "wof:geomhash":"29c8a35d8d68521e6fdd39c8ee9a751c",
+    "wof:geomhash":"9d3245074823f31d78ba81269764e81b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1091682041,
-    "wof:lastmodified":1627522166,
+    "wof:lastmodified":1695886634,
     "wof:name":"Riverstown/Annandale",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/168/208/9/1091682089.geojson
+++ b/data/109/168/208/9/1091682089.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002113,
-    "geom:area_square_m":25926041.336375,
+    "geom:area_square_m":25926124.285558,
     "geom:bbox":"-58.542417,7.17484,-58.482696,7.232172",
     "geom:latitude":7.198275,
     "geom:longitude":-58.508407,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"GY.PM.ZE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473878993,
-    "wof:geomhash":"087f38e7d726d3b4abb267ce4a96da0b",
+    "wof:geomhash":"66af996aec04019e8bf17a6d102074dc",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1091682089,
-    "wof:lastmodified":1627522170,
+    "wof:lastmodified":1695886637,
     "wof:name":"Zorg-E -Vlygt/Aberdeen",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/168/213/3/1091682133.geojson
+++ b/data/109/168/213/3/1091682133.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001419,
-    "geom:area_square_m":17424034.981657,
+    "geom:area_square_m":17424044.166089,
     "geom:bbox":"-58.234283,6.694577,-58.197083,6.749898",
     "geom:latitude":6.719904,
     "geom:longitude":-58.216601,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.ES.PT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473878994,
-    "wof:geomhash":"379a06ef05b5b99fe584752c5f6180da",
+    "wof:geomhash":"ae81b02f6bf6119265991e1d88a4e486",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091682133,
-    "wof:lastmodified":1627522166,
+    "wof:lastmodified":1695886634,
     "wof:name":"Patentia/Toevlugt",
     "wof:parent_id":85671767,
     "wof:placetype":"county",

--- a/data/109/168/217/3/1091682173.geojson
+++ b/data/109/168/217/3/1091682173.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005355,
-    "geom:area_square_m":65761095.67,
+    "geom:area_square_m":65761254.839685,
     "geom:bbox":"-58.304875,6.702977,-58.22322,6.796105",
     "geom:latitude":6.750504,
     "geom:longitude":-58.268986,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.ES.CP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473878996,
-    "wof:geomhash":"28806ce28141d857406bcecd796dc342",
+    "wof:geomhash":"48f288d9276d2026735b928bcd44b8d6",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091682173,
-    "wof:lastmodified":1627522163,
+    "wof:lastmodified":1695886631,
     "wof:name":"Canals Polder",
     "wof:parent_id":85671767,
     "wof:placetype":"county",

--- a/data/109/168/222/3/1091682223.geojson
+++ b/data/109/168/222/3/1091682223.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000621,
-    "geom:area_square_m":7623986.371321,
+    "geom:area_square_m":7623921.830564,
     "geom:bbox":"-58.226718,6.749339,-58.196839,6.779041",
     "geom:latitude":6.763702,
     "geom:longitude":-58.211664,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.ES.NL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473878999,
-    "wof:geomhash":"e161c744e25185e68bb413b33805f179",
+    "wof:geomhash":"8b7cdba377157c57482f623d5b66d24b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091682223,
-    "wof:lastmodified":1627522166,
+    "wof:lastmodified":1695886634,
     "wof:name":"Nismes/La Grange",
     "wof:parent_id":85671767,
     "wof:placetype":"county",

--- a/data/109/168/227/3/1091682273.geojson
+++ b/data/109/168/227/3/1091682273.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001502,
-    "geom:area_square_m":18445004.317495,
+    "geom:area_square_m":18444938.102273,
     "geom:bbox":"-58.246211,6.762787,-58.187084,6.808892",
     "geom:latitude":6.787509,
     "geom:longitude":-58.221313,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.ES.MZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879000,
-    "wof:geomhash":"baf734c2969de6be234b0980990d259c",
+    "wof:geomhash":"327c1530a4bc4d9d4df7ddb26ed7b75a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091682273,
-    "wof:lastmodified":1627522166,
+    "wof:lastmodified":1695886634,
     "wof:name":"Meer Zorgen/Malgre Tout",
     "wof:parent_id":85671767,
     "wof:placetype":"county",

--- a/data/109/168/230/7/1091682307.geojson
+++ b/data/109/168/230/7/1091682307.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000774,
-    "geom:area_square_m":9502709.506059,
+    "geom:area_square_m":9502904.66094,
     "geom:bbox":"-58.226082,6.795886,-58.180328,6.825389",
     "geom:latitude":6.809251,
     "geom:longitude":-58.198968,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.ES.KP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879002,
-    "wof:geomhash":"154206fea8065e3c4df22a6478833e13",
+    "wof:geomhash":"76471183ee2618f2f9c0e9248e20b259",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091682307,
-    "wof:lastmodified":1627522165,
+    "wof:lastmodified":1695886633,
     "wof:name":"Klein Pouderoyen/Best",
     "wof:parent_id":85671767,
     "wof:placetype":"county",

--- a/data/109/168/235/3/1091682353.geojson
+++ b/data/109/168/235/3/1091682353.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001502,
-    "geom:area_square_m":18444095.134964,
+    "geom:area_square_m":18444097.173197,
     "geom:bbox":"-58.269446,6.79123,-58.240766,6.868223",
     "geom:latitude":6.828386,
     "geom:longitude":-58.257202,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.ES.BH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879003,
-    "wof:geomhash":"5a7e69cc096e60600a11b8154d085e38",
+    "wof:geomhash":"eb352a273f6d5db839254d452df08040",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091682353,
-    "wof:lastmodified":1627522163,
+    "wof:lastmodified":1695886631,
     "wof:name":"Blankenburg/Hague",
     "wof:parent_id":85671767,
     "wof:placetype":"county",

--- a/data/109/168/239/9/1091682399.geojson
+++ b/data/109/168/239/9/1091682399.geojson
@@ -49,7 +49,10 @@
         85671767
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"300"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"GY",
     "wof:created":1473879005,
     "wof:geomhash":"57db48141a57a8b53724dfbd34256971",
@@ -62,7 +65,7 @@
         }
     ],
     "wof:id":1091682399,
-    "wof:lastmodified":1694498077,
+    "wof:lastmodified":1695886417,
     "wof:name":"Unorganized",
     "wof:parent_id":85671767,
     "wof:placetype":"county",

--- a/data/109/168/243/3/1091682433.geojson
+++ b/data/109/168/243/3/1091682433.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002789,
-    "geom:area_square_m":34240702.811271,
+    "geom:area_square_m":34240628.670998,
     "geom:bbox":"-58.30431,6.79123,-58.258513,6.881668",
     "geom:latitude":6.836664,
     "geom:longitude":-58.283352,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.ES.CI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879006,
-    "wof:geomhash":"eea384f98a75210d55390a944b1223e3",
+    "wof:geomhash":"ea017dd6530e0f2544aab3adeb52136a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091682433,
-    "wof:lastmodified":1627522164,
+    "wof:lastmodified":1695886632,
     "wof:name":"Cornelia Ida/Stewartville",
     "wof:parent_id":85671767,
     "wof:placetype":"county",

--- a/data/109/168/246/3/1091682463.geojson
+++ b/data/109/168/246/3/1091682463.geojson
@@ -52,7 +52,10 @@
         85671767
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"300"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"GY",
     "wof:created":1473879008,
     "wof:geomhash":"88bc842d45f740706b5f36fd5d657c91",
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":1091682463,
-    "wof:lastmodified":1694498077,
+    "wof:lastmodified":1695886417,
     "wof:name":"Unorganized",
     "wof:parent_id":85671767,
     "wof:placetype":"county",

--- a/data/109/168/248/3/1091682483.geojson
+++ b/data/109/168/248/3/1091682483.geojson
@@ -65,8 +65,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"GY.MA.UN"
+        "hasc:id":"GY.MA.UN",
+        "meso:local_id":"300"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"GY",
     "wof:created":1473879009,
     "wof:geomhash":"6b661336985c567d64e0f0b5b7790ba8",
@@ -79,7 +81,7 @@
         }
     ],
     "wof:id":1091682483,
-    "wof:lastmodified":1694492674,
+    "wof:lastmodified":1695886636,
     "wof:name":"Unorganized",
     "wof:parent_id":85671767,
     "wof:placetype":"county",

--- a/data/109/168/252/1/1091682521.geojson
+++ b/data/109/168/252/1/1091682521.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005244,
-    "geom:area_square_m":64380112.185221,
+    "geom:area_square_m":64379983.265846,
     "geom:bbox":"-58.373037,6.798662,-58.295059,6.888739",
     "geom:latitude":6.840866,
     "geom:longitude":-58.330491,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.ES.UT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879011,
-    "wof:geomhash":"6d30e5576e4c69f99c0a2de7059a7dc4",
+    "wof:geomhash":"7811b84788dc961c2f7a2c1ac3d8a3a4",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091682521,
-    "wof:lastmodified":1627522169,
+    "wof:lastmodified":1695886636,
     "wof:name":"Uitvlugt/Tuschen",
     "wof:parent_id":85671767,
     "wof:placetype":"county",

--- a/data/109/168/255/5/1091682555.geojson
+++ b/data/109/168/255/5/1091682555.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000706,
-    "geom:area_square_m":8666563.317046,
+    "geom:area_square_m":8666682.899853,
     "geom:bbox":"-58.381229,6.84533,-58.356613,6.881655",
     "geom:latitude":6.861504,
     "geom:longitude":-58.368323,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.ES.VG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879013,
-    "wof:geomhash":"b69c839fdc46657d410d110ca79bf883",
+    "wof:geomhash":"e62c8ad2badff7365159197dfa4c13a0",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091682555,
-    "wof:lastmodified":1627522169,
+    "wof:lastmodified":1695886636,
     "wof:name":"Vergenoegen/Greenwich Park",
     "wof:parent_id":85671767,
     "wof:placetype":"county",

--- a/data/109/168/257/7/1091682577.geojson
+++ b/data/109/168/257/7/1091682577.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000843,
-    "geom:area_square_m":10349604.33199,
+    "geom:area_square_m":10349417.500781,
     "geom:bbox":"-58.421317,6.839564,-58.38083,6.872252",
     "geom:latitude":6.858056,
     "geom:longitude":-58.398557,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.ES.GH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879014,
-    "wof:geomhash":"d53f44239c441589f3a99c7ab7244e22",
+    "wof:geomhash":"86bed13c7e8f189e2ef27f8e4031c41f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091682577,
-    "wof:lastmodified":1627522164,
+    "wof:lastmodified":1695886632,
     "wof:name":"Good Hope/Hydronie",
     "wof:parent_id":85671767,
     "wof:placetype":"county",

--- a/data/109/168/261/1/1091682611.geojson
+++ b/data/109/168/261/1/1091682611.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000896,
-    "geom:area_square_m":10998092.035894,
+    "geom:area_square_m":10998166.06588,
     "geom:bbox":"-58.450119,6.819453,-58.406843,6.862319",
     "geom:latitude":6.840788,
     "geom:longitude":-58.427922,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.ES.PM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879016,
-    "wof:geomhash":"d92b6e68594d84e1896050fbb2730354",
+    "wof:geomhash":"2dce6c5aa75a2874e4af9bb0986f021d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091682611,
-    "wof:lastmodified":1627522166,
+    "wof:lastmodified":1695886634,
     "wof:name":"Parika/Mora",
     "wof:parent_id":85671767,
     "wof:placetype":"county",

--- a/data/109/168/265/5/1091682655.geojson
+++ b/data/109/168/265/5/1091682655.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004366,
-    "geom:area_square_m":53589792.750202,
+    "geom:area_square_m":53589654.936311,
     "geom:bbox":"-58.473778,6.880389,-58.342945,6.972084",
     "geom:latitude":6.934591,
     "geom:longitude":-58.410872,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.ES.LE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879017,
-    "wof:geomhash":"78aa6cc445f63f85d24bd526991b48b3",
+    "wof:geomhash":"c1afc20858e23bda3bc9c3a29a1fcbc6",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091682655,
-    "wof:lastmodified":1627522165,
+    "wof:lastmodified":1695886633,
     "wof:name":"Leguan (Essequibo Islands)",
     "wof:parent_id":85671767,
     "wof:placetype":"county",

--- a/data/109/168/269/7/1091682697.geojson
+++ b/data/109/168/269/7/1091682697.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001671,
-    "geom:area_square_m":20518596.138133,
+    "geom:area_square_m":20518537.645187,
     "geom:bbox":"-58.251098,6.801564,-58.196349,6.857889",
     "geom:latitude":6.82781,
     "geom:longitude":-58.22926,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.ES.NF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879019,
-    "wof:geomhash":"c74c23c7f77800843de66af1f4bba18a",
+    "wof:geomhash":"1ab49e31229c11702e401ae1e745ec90",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091682697,
-    "wof:lastmodified":1627522166,
+    "wof:lastmodified":1695886634,
     "wof:name":"Nouvelle Flanders/La Jalousie",
     "wof:parent_id":85671767,
     "wof:placetype":"county",

--- a/data/109/168/273/9/1091682739.geojson
+++ b/data/109/168/273/9/1091682739.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004107,
-    "geom:area_square_m":50405144.614368,
+    "geom:area_square_m":50405374.684629,
     "geom:bbox":"-58.520282,6.898734,-58.40461,7.028528",
     "geom:latitude":6.969439,
     "geom:longitude":-58.45671,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.ES.WE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879020,
-    "wof:geomhash":"707d75916d043f9bd1453126625c7b91",
+    "wof:geomhash":"41ba59636a3b070d4e4488fa7cdfe319",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091682739,
-    "wof:lastmodified":1627522169,
+    "wof:lastmodified":1695886636,
     "wof:name":"Wakenaam (Essequibo Islands)",
     "wof:parent_id":85671767,
     "wof:placetype":"county",

--- a/data/109/168/277/9/1091682779.geojson
+++ b/data/109/168/277/9/1091682779.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.083002,
-    "geom:area_square_m":1019871980.368627,
+    "geom:area_square_m":1019871668.5704,
     "geom:bbox":"-58.444375,6.089988,-58.198396,6.704215",
     "geom:latitude":6.433985,
     "geom:longitude":-58.336709,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.ES.AD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879022,
-    "wof:geomhash":"0f6bb4fb5a41a531459fce7825604c65",
+    "wof:geomhash":"cd619f4e5f1b3e3c1b120c3eb9cc56fb",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091682779,
-    "wof:lastmodified":1627522163,
+    "wof:lastmodified":1695886631,
     "wof:name":"Amsterdam (Demerara River)/Vriesland",
     "wof:parent_id":85671767,
     "wof:placetype":"county",

--- a/data/109/168/278/1/1091682781.geojson
+++ b/data/109/168/278/1/1091682781.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00088,
-    "geom:area_square_m":10802106.754095,
+    "geom:area_square_m":10801974.478908,
     "geom:bbox":"-58.260762,6.697543,-58.229792,6.73043",
     "geom:latitude":6.714058,
     "geom:longitude":-58.245368,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.ES.CN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879023,
-    "wof:geomhash":"ef87239b38e767194d73f0e54ec46479",
+    "wof:geomhash":"dc089fbeaaed1e1619cfd28fb47b18f6",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091682781,
-    "wof:lastmodified":1627522163,
+    "wof:lastmodified":1695886631,
     "wof:name":"Canal No.2 (part)+The Belle+Little Alliance",
     "wof:parent_id":85671767,
     "wof:placetype":"county",

--- a/data/109/168/294/9/1091682949.geojson
+++ b/data/109/168/294/9/1091682949.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001515,
-    "geom:area_square_m":18598325.798356,
+    "geom:area_square_m":18598450.387964,
     "geom:bbox":"-58.570446,6.854583,-58.507915,6.94875",
     "geom:latitude":6.909798,
     "geom:longitude":-58.538186,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.ES.SB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879031,
-    "wof:geomhash":"541d95895b1f1c6ab2d7f0d16081f91b",
+    "wof:geomhash":"a926881d882d34ce830641f6eb6f5fa8",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091682949,
-    "wof:lastmodified":1627522167,
+    "wof:lastmodified":1695886635,
     "wof:name":"Sparta/Bonasika and Rest of Essequibo Islands",
     "wof:parent_id":85671767,
     "wof:placetype":"county",

--- a/data/109/168/300/9/1091683009.geojson
+++ b/data/109/168/300/9/1091683009.geojson
@@ -52,7 +52,10 @@
         85671761
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"400"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"GY",
     "wof:created":1473879032,
     "wof:geomhash":"ead9436025b022f260d1eef99e5842ef",
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":1091683009,
-    "wof:lastmodified":1694498077,
+    "wof:lastmodified":1695886417,
     "wof:name":"Unorganized",
     "wof:parent_id":85671761,
     "wof:placetype":"county",

--- a/data/109/168/304/5/1091683045.geojson
+++ b/data/109/168/304/5/1091683045.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002803,
-    "geom:area_square_m":34424495.334837,
+    "geom:area_square_m":34424325.510374,
     "geom:bbox":"-57.967492,6.598783,-57.891444,6.671848",
     "geom:latitude":6.636279,
     "geom:longitude":-57.928193,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.DE.CG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879034,
-    "wof:geomhash":"04ee8d3299761ac177b6f06794551774",
+    "wof:geomhash":"4fb1a1ab39b2deb8db4ed5aed34d3404",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091683045,
-    "wof:lastmodified":1627522163,
+    "wof:lastmodified":1695886631,
     "wof:name":"Cane Grove Land Development Scheme",
     "wof:parent_id":85671761,
     "wof:placetype":"county",

--- a/data/109/168/309/1/1091683091.geojson
+++ b/data/109/168/309/1/1091683091.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001511,
-    "geom:area_square_m":18553746.892573,
+    "geom:area_square_m":18553744.157701,
     "geom:bbox":"-57.959555,6.659244,-57.912258,6.720415",
     "geom:latitude":6.686157,
     "geom:longitude":-57.932693,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.DE.VU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879036,
-    "wof:geomhash":"c21f124e6b9fe5476350786a2161aadc",
+    "wof:geomhash":"ca056e3ea6b99eed6cf686d2f7e627d9",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091683091,
-    "wof:lastmodified":1627522169,
+    "wof:lastmodified":1695886636,
     "wof:name":"Vereeniging/Unity",
     "wof:parent_id":85671761,
     "wof:placetype":"county",

--- a/data/109/168/313/1/1091683131.geojson
+++ b/data/109/168/313/1/1091683131.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002073,
-    "geom:area_square_m":25455125.258521,
+    "geom:area_square_m":25455007.885368,
     "geom:bbox":"-58.129653,6.719021,-58.08501,6.834583",
     "geom:latitude":6.782077,
     "geom:longitude":-58.108417,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.DE.PI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879037,
-    "wof:geomhash":"350c3c087beb4e79e796f678271effae",
+    "wof:geomhash":"c598afb5fe3eddd32647448de654310e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091683131,
-    "wof:lastmodified":1627522166,
+    "wof:lastmodified":1695886634,
     "wof:name":"Plaisance/Industry",
     "wof:parent_id":85671761,
     "wof:placetype":"county",

--- a/data/109/168/317/1/1091683171.geojson
+++ b/data/109/168/317/1/1091683171.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001747,
-    "geom:area_square_m":21450858.162896,
+    "geom:area_square_m":21451024.308003,
     "geom:bbox":"-58.192178,6.73611,-58.120444,6.78173",
     "geom:latitude":6.758262,
     "geom:longitude":-58.155658,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.DE.ER"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879039,
-    "wof:geomhash":"3a6540e919ea974ca17dc16090ab0ec9",
+    "wof:geomhash":"2ea46680cdbac75efb8193d0ee76b4b5",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091683171,
-    "wof:lastmodified":1627522164,
+    "wof:lastmodified":1695886632,
     "wof:name":"Eccles/Ramsburg",
     "wof:parent_id":85671761,
     "wof:placetype":"county",

--- a/data/109/168/320/9/1091683209.geojson
+++ b/data/109/168/320/9/1091683209.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000933,
-    "geom:area_square_m":11460774.079214,
+    "geom:area_square_m":11460800.152533,
     "geom:bbox":"-58.165694,6.711112,-58.125746,6.745194",
     "geom:latitude":6.726614,
     "geom:longitude":-58.145762,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.DE.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879040,
-    "wof:geomhash":"bae42dd2090bcc0724307451f6689478",
+    "wof:geomhash":"a1e1b2bbe72e3a861edc177112a9548e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091683209,
-    "wof:lastmodified":1627522166,
+    "wof:lastmodified":1695886634,
     "wof:name":"Mocha/Arcadia",
     "wof:parent_id":85671761,
     "wof:placetype":"county",

--- a/data/109/168/322/5/1091683225.geojson
+++ b/data/109/168/322/5/1091683225.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000963,
-    "geom:area_square_m":11830378.606682,
+    "geom:area_square_m":11830275.793582,
     "geom:bbox":"-58.197106,6.717879,-58.158684,6.753989",
     "geom:latitude":6.736992,
     "geom:longitude":-58.178234,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.DE.HL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879042,
-    "wof:geomhash":"78fbad5d6208e3e65805feddcb037540",
+    "wof:geomhash":"3cba08812481ee421363310a04b351eb",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091683225,
-    "wof:lastmodified":1627522164,
+    "wof:lastmodified":1695886632,
     "wof:name":"Herstelling/Little Diamond",
     "wof:parent_id":85671761,
     "wof:placetype":"county",

--- a/data/109/168/326/3/1091683263.geojson
+++ b/data/109/168/326/3/1091683263.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001801,
-    "geom:area_square_m":22111946.945991,
+    "geom:area_square_m":22111801.554613,
     "geom:bbox":"-58.197109,6.679906,-58.130599,6.730494",
     "geom:latitude":6.70347,
     "geom:longitude":-58.163041,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.DE.DG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879044,
-    "wof:geomhash":"042041f09ceb3c364d3d7d5eae79eb9d",
+    "wof:geomhash":"f369ca4dff5a67e3e1dd1aae476db4ed",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091683263,
-    "wof:lastmodified":1627522164,
+    "wof:lastmodified":1695886633,
     "wof:name":"Diamond/Golden Grove",
     "wof:parent_id":85671761,
     "wof:placetype":"county",

--- a/data/109/168/331/1/1091683311.geojson
+++ b/data/109/168/331/1/1091683311.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004303,
-    "geom:area_square_m":52854343.412186,
+    "geom:area_square_m":52854663.986484,
     "geom:bbox":"-58.222219,6.574216,-58.136509,6.690963",
     "geom:latitude":6.637945,
     "geom:longitude":-58.185501,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.DE.GS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879045,
-    "wof:geomhash":"022f10755e72c169ed3a3ef1091e9072",
+    "wof:geomhash":"6a115ca1c45b804f8253ccca64cd67c5",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091683311,
-    "wof:lastmodified":1627522164,
+    "wof:lastmodified":1695886633,
     "wof:name":"Good Success/Caledonia",
     "wof:parent_id":85671761,
     "wof:placetype":"county",

--- a/data/109/168/335/5/1091683355.geojson
+++ b/data/109/168/335/5/1091683355.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002305,
-    "geom:area_square_m":28319382.487047,
+    "geom:area_square_m":28319420.086406,
     "geom:bbox":"-58.254176,6.519406,-58.182205,6.581819",
     "geom:latitude":6.55252,
     "geom:longitude":-58.21797,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.DE.TH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879047,
-    "wof:geomhash":"110a27f0d471232c6cb0c42bc1e0674d",
+    "wof:geomhash":"673f855bb6726a39abc24b19275757bd",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091683355,
-    "wof:lastmodified":1627522167,
+    "wof:lastmodified":1695886635,
     "wof:name":"Te Huist Coverden/Soesdyke",
     "wof:parent_id":85671761,
     "wof:placetype":"county",

--- a/data/109/168/340/3/1091683403.geojson
+++ b/data/109/168/340/3/1091683403.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003785,
-    "geom:area_square_m":46470666.036084,
+    "geom:area_square_m":46470740.436992,
     "geom:bbox":"-58.180085,6.762957,-58.108623,6.836222",
     "geom:latitude":6.802125,
     "geom:longitude":-58.141887,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"GY.DE.GM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879048,
-    "wof:geomhash":"c9b22257ec847fba76711e019c9f2edc",
+    "wof:geomhash":"9fa805963d7145f5f4a946a57f619121",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1091683403,
-    "wof:lastmodified":1627522164,
+    "wof:lastmodified":1695886633,
     "wof:name":"City of Georgetown",
     "wof:parent_id":85671761,
     "wof:placetype":"county",

--- a/data/109/168/342/7/1091683427.geojson
+++ b/data/109/168/342/7/1091683427.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.047792,
-    "geom:area_square_m":587340898.715927,
+    "geom:area_square_m":587340825.769405,
     "geom:bbox":"-58.31248,6.088236,-58.118742,6.60601",
     "geom:latitude":6.344681,
     "geom:longitude":-58.230796,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.DE.SL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879050,
-    "wof:geomhash":"6db0f261758ac83752a076a5829ced6d",
+    "wof:geomhash":"74737c9e6d8599306b2b6f3ac541bfd3",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091683427,
-    "wof:lastmodified":1627522167,
+    "wof:lastmodified":1695886635,
     "wof:name":"Soesdyke-Linden highway (including Timehri)",
     "wof:parent_id":85671761,
     "wof:placetype":"county",

--- a/data/109/168/347/1/1091683471.geojson
+++ b/data/109/168/347/1/1091683471.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.061982,
-    "geom:area_square_m":761621003.671245,
+    "geom:area_square_m":761621200.857634,
     "geom:bbox":"-58.213641,6.087378,-57.878383,6.614815",
     "geom:latitude":6.410617,
     "geom:longitude":-58.088864,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.DE.SC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879051,
-    "wof:geomhash":"93fef9ec5e4e6499b59ab74e3b156c40",
+    "wof:geomhash":"abebad973788d9ca539964d4f955dfbc",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091683471,
-    "wof:lastmodified":1627522167,
+    "wof:lastmodified":1695886635,
     "wof:name":"St. Cuthberts/Orange Nassau (Mahaica River)",
     "wof:parent_id":85671761,
     "wof:placetype":"county",

--- a/data/109/168/351/1/1091683511.geojson
+++ b/data/109/168/351/1/1091683511.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.156163,
-    "geom:area_square_m":1919498250.709674,
+    "geom:area_square_m":1919497970.912698,
     "geom:bbox":"-58.151081,5.900513,-57.684814,6.601848",
     "geom:latitude":6.250058,
     "geom:longitude":-57.912273,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"GY.MA.RS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879052,
-    "wof:geomhash":"91eeace4f6cd5008c15ee4f3f4c03373",
+    "wof:geomhash":"8f47ec7f1ca142825dd751c84c708774",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1091683511,
-    "wof:lastmodified":1627522167,
+    "wof:lastmodified":1695886635,
     "wof:name":"Unorganized",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/168/354/5/1091683545.geojson
+++ b/data/109/168/354/5/1091683545.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009338,
-    "geom:area_square_m":114772831.057817,
+    "geom:area_square_m":114772899.681645,
     "geom:bbox":"-57.692823,6.226063,-57.53268,6.370235",
     "geom:latitude":6.290719,
     "geom:longitude":-57.621951,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"GY.MA.GN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879054,
-    "wof:geomhash":"4cf06f7b4bc4a13a6b3bf54834e35662",
+    "wof:geomhash":"ccd574658c3837b7f284decbb17076c3",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1091683545,
-    "wof:lastmodified":1627522167,
+    "wof:lastmodified":1695886635,
     "wof:name":"Unorganized",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/168/358/5/1091683585.geojson
+++ b/data/109/168/358/5/1091683585.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0028,
-    "geom:area_square_m":34419173.219244,
+    "geom:area_square_m":34419278.417984,
     "geom:bbox":"-57.619116,6.272077,-57.530861,6.324425",
     "geom:latitude":6.30074,
     "geom:longitude":-57.569747,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"GY.MA.RZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879055,
-    "wof:geomhash":"efa49598fbe177d8b260a6fe745ee211",
+    "wof:geomhash":"33405ac099325c5efc9cd9442175dfd6",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1091683585,
-    "wof:lastmodified":1627522167,
+    "wof:lastmodified":1695886635,
     "wof:name":"Rosignol/Zeelust",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/168/360/9/1091683609.geojson
+++ b/data/109/168/360/9/1091683609.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001498,
-    "geom:area_square_m":18414965.408731,
+    "geom:area_square_m":18414917.296693,
     "geom:bbox":"-57.619594,6.319984,-57.555356,6.353017",
     "geom:latitude":6.334583,
     "geom:longitude":-57.58774,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"GY.MA.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879057,
-    "wof:geomhash":"ecdc5501f4f7c7a174b6b97a908e067b",
+    "wof:geomhash":"9cb789bcc5172f1bc002b5fb66980501",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1091683609,
-    "wof:lastmodified":1627522163,
+    "wof:lastmodified":1695886632,
     "wof:name":"Bel Air/Woodlands",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/168/363/3/1091683633.geojson
+++ b/data/109/168/363/3/1091683633.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001019,
-    "geom:area_square_m":12524269.149741,
+    "geom:area_square_m":12524280.977973,
     "geom:bbox":"-57.610252,6.349939,-57.568195,6.389047",
     "geom:latitude":6.366203,
     "geom:longitude":-57.588536,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"GY.MA.WP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879058,
-    "wof:geomhash":"79f6bbd90f00f6fa2dc73ae003f6c9b3",
+    "wof:geomhash":"73152ea7569e8df660d9c2bbc7729a77",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1091683633,
-    "wof:lastmodified":1627522169,
+    "wof:lastmodified":1695886636,
     "wof:name":"Woodley Park/Bath",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/168/364/3/1091683643.geojson
+++ b/data/109/168/364/3/1091683643.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008356,
-    "geom:area_square_m":102688575.084667,
+    "geom:area_square_m":102688523.006554,
     "geom:bbox":"-57.707826,6.31101,-57.583313,6.44746",
     "geom:latitude":6.38081,
     "geom:longitude":-57.650502,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"GY.MA.NU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879060,
-    "wof:geomhash":"7cebe5680abafde46425cdbfab08bcec",
+    "wof:geomhash":"8a5e08dd6d530b7274234c17b8f6a761",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1091683643,
-    "wof:lastmodified":1627522166,
+    "wof:lastmodified":1695886634,
     "wof:name":"Naarstigheid/Union",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/168/367/5/1091683675.geojson
+++ b/data/109/168/367/5/1091683675.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005353,
-    "geom:area_square_m":65775043.678807,
+    "geom:area_square_m":65774940.234636,
     "geom:bbox":"-57.803574,6.419638,-57.720748,6.520611",
     "geom:latitude":6.471909,
     "geom:longitude":-57.765146,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"GY.MA.AM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879062,
-    "wof:geomhash":"f3341d9efce93c8b7a41eb2465bc73e3",
+    "wof:geomhash":"4298b51730e940457a33edd455f53d47",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1091683675,
-    "wof:lastmodified":1627522163,
+    "wof:lastmodified":1695886632,
     "wof:name":"Abary/Mahaicony",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/168/372/9/1091683729.geojson
+++ b/data/109/168/372/9/1091683729.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006046,
-    "geom:area_square_m":74274419.535461,
+    "geom:area_square_m":74274421.546054,
     "geom:bbox":"-57.861074,6.508222,-57.750563,6.598266",
     "geom:latitude":6.549771,
     "geom:longitude":-57.807279,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"GY.MA.CH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879063,
-    "wof:geomhash":"bcf929d473d192ae30f2dae53c6e60da",
+    "wof:geomhash":"2672ca5f9d951d267ef1a8162772f5a3",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1091683729,
-    "wof:lastmodified":1627522163,
+    "wof:lastmodified":1695886632,
     "wof:name":"Chance/Hamlet",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/168/376/1/1091683761.geojson
+++ b/data/109/168/376/1/1091683761.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0702,
-    "geom:area_square_m":863272327.382797,
+    "geom:area_square_m":863272812.401861,
     "geom:bbox":"-57.947706,5.78443,-57.529972,6.262777",
     "geom:latitude":6.004069,
     "geom:longitude":-57.726746,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.MA.WB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879065,
-    "wof:geomhash":"575de48051e6ccbb6304fa1f89d9eb7a",
+    "wof:geomhash":"fee2f7abf27387d83fc9096ba482602e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091683761,
-    "wof:lastmodified":1627522169,
+    "wof:lastmodified":1695886637,
     "wof:name":"West Bank Berbice (river)",
     "wof:parent_id":85671737,
     "wof:placetype":"county",

--- a/data/109/168/380/3/1091683803.geojson
+++ b/data/109/168/380/3/1091683803.geojson
@@ -54,6 +54,7 @@
     "wof:concordances":{
         "hasc:id":"GY.EB.BP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879066,
     "wof:geomhash":"a8721961c029875042ec51b50c1b5db0",
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1091683803,
-    "wof:lastmodified":1694498070,
+    "wof:lastmodified":1695886267,
     "wof:name":"Black Bush Polder Land Dev Schm",
     "wof:parent_id":85671757,
     "wof:placetype":"county",

--- a/data/109/168/384/3/1091683843.geojson
+++ b/data/109/168/384/3/1091683843.geojson
@@ -54,6 +54,7 @@
     "wof:concordances":{
         "hasc:id":"GY.EB.BL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879067,
     "wof:geomhash":"cd97607ab100590bf752c212483b70e1",
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1091683843,
-    "wof:lastmodified":1694498071,
+    "wof:lastmodified":1695886270,
     "wof:name":"Bush Lot/Adventure",
     "wof:parent_id":85671757,
     "wof:placetype":"county",

--- a/data/109/168/387/9/1091683879.geojson
+++ b/data/109/168/387/9/1091683879.geojson
@@ -54,6 +54,7 @@
     "wof:concordances":{
         "hasc:id":"GY.EB.WB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879069,
     "wof:geomhash":"0cc3c7aeee038d87adf1dbaf031f4d51",
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1091683879,
-    "wof:lastmodified":1694498077,
+    "wof:lastmodified":1695886422,
     "wof:name":"Whim/Bloomfield",
     "wof:parent_id":85671757,
     "wof:placetype":"county",

--- a/data/109/168/392/7/1091683927.geojson
+++ b/data/109/168/392/7/1091683927.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.214118,
-    "geom:area_square_m":2635738131.517486,
+    "geom:area_square_m":2635738053.909589,
     "geom:bbox":"-60.566534,5.170512,-59.947182,5.719051",
     "geom:latitude":5.425232,
     "geom:longitude":-60.298851,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.CU.KK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879071,
-    "wof:geomhash":"85f7e36f19b3972684c6d80c240831a2",
+    "wof:geomhash":"fe856d2beac61e9f65e63e7b49a7ec16",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091683927,
-    "wof:lastmodified":1627522165,
+    "wof:lastmodified":1695886633,
     "wof:name":"Karambaru to Tukui River, Phillipi",
     "wof:parent_id":85671773,
     "wof:placetype":"county",

--- a/data/109/168/397/5/1091683975.geojson
+++ b/data/109/168/397/5/1091683975.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.045801,
-    "geom:area_square_m":563445671.86111,
+    "geom:area_square_m":563445595.801145,
     "geom:bbox":"-60.566112,5.680136,-60.262375,5.948836",
     "geom:latitude":5.795896,
     "geom:longitude":-60.387719,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.CU.JK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879072,
-    "wof:geomhash":"d61b18772ccdb9d20850de51f8367d62",
+    "wof:geomhash":"fb003d92f4908ae970d44da437e7483b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091683975,
-    "wof:lastmodified":1627522165,
+    "wof:lastmodified":1695886633,
     "wof:name":"Jawalla, Kubenang River",
     "wof:parent_id":85671773,
     "wof:placetype":"county",

--- a/data/109/168/401/9/1091684019.geojson
+++ b/data/109/168/401/9/1091684019.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010673,
-    "geom:area_square_m":131284293.152089,
+    "geom:area_square_m":131284543.729008,
     "geom:bbox":"-60.853033,5.795781,-60.717943,5.928333",
     "geom:latitude":5.857184,
     "geom:longitude":-60.795391,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.CU.WA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879073,
-    "wof:geomhash":"a80fb392a3a7cbd17cc897ed21eccb2e",
+    "wof:geomhash":"f2c4e6614646cb9a3b0dc87476805256",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091684019,
-    "wof:lastmodified":1627522169,
+    "wof:lastmodified":1695886637,
     "wof:name":"Waramadan",
     "wof:parent_id":85671773,
     "wof:placetype":"county",

--- a/data/109/168/404/7/1091684047.geojson
+++ b/data/109/168/404/7/1091684047.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.140884,
-    "geom:area_square_m":1732480567.079583,
+    "geom:area_square_m":1732480653.500764,
     "geom:bbox":"-60.858852,5.718883,-60.401674,6.419919",
     "geom:latitude":6.010208,
     "geom:longitude":-60.604784,
@@ -73,9 +73,10 @@
     "wof:concordances":{
         "hasc:id":"GY.CU.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879075,
-    "wof:geomhash":"5abde8e3a9c179bc25554ff07d6d5ad6",
+    "wof:geomhash":"9954861809bb300f7ec9477272643ed9",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1091684047,
-    "wof:lastmodified":1627522165,
+    "wof:lastmodified":1695886633,
     "wof:name":"Kamarang",
     "wof:parent_id":85671773,
     "wof:placetype":"county",

--- a/data/109/168/421/3/1091684213.geojson
+++ b/data/109/168/421/3/1091684213.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.175149,
-    "geom:area_square_m":14480294922.685011,
+    "geom:area_square_m":14480295363.544132,
     "geom:bbox":"-60.096266,4.058797,-58.357888,5.426874",
     "geom:latitude":4.773541,
     "geom:longitude":-59.222885,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.PT.UN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879076,
-    "wof:geomhash":"f72996ad4b88d94083fb0062687d070e",
+    "wof:geomhash":"fd17c63d7db729a187e0cc1dfa7f7889",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091684213,
-    "wof:lastmodified":1627522168,
+    "wof:lastmodified":1695886636,
     "wof:name":"Unorganized",
     "wof:parent_id":85671739,
     "wof:placetype":"county",

--- a/data/109/168/426/7/1091684267.geojson
+++ b/data/109/168/426/7/1091684267.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.027956,
-    "geom:area_square_m":344390514.756941,
+    "geom:area_square_m":344390627.424705,
     "geom:bbox":"-60.005545,4.852006,-59.766205,5.07328",
     "geom:latitude":4.959217,
     "geom:longitude":-59.881096,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.PT.KW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879084,
-    "wof:geomhash":"0f95f6e8c7b1c707280df97861817786",
+    "wof:geomhash":"fbeec7aafe1541c8b05ef6004e1fff78",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091684267,
-    "wof:lastmodified":1627522165,
+    "wof:lastmodified":1695886633,
     "wof:name":"Kopanang, Waipa, Kenepai",
     "wof:parent_id":85671739,
     "wof:placetype":"county",

--- a/data/109/168/431/5/1091684315.geojson
+++ b/data/109/168/431/5/1091684315.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006029,
-    "geom:area_square_m":74266203.94827,
+    "geom:area_square_m":74266371.545779,
     "geom:bbox":"-59.989527,4.959864,-59.8898,5.051871",
     "geom:latitude":5.007002,
     "geom:longitude":-59.946021,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.PT.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879085,
-    "wof:geomhash":"f49308c073979f8f78956ae81fe23cf2",
+    "wof:geomhash":"5483ebd762b49c8d395f9aa0c49b238b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091684315,
-    "wof:lastmodified":1627522165,
+    "wof:lastmodified":1695886633,
     "wof:name":"Kaibarupai",
     "wof:parent_id":85671739,
     "wof:placetype":"county",

--- a/data/109/168/434/3/1091684343.geojson
+++ b/data/109/168/434/3/1091684343.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.135007,
-    "geom:area_square_m":1664850171.945305,
+    "geom:area_square_m":1664849924.811291,
     "geom:bbox":"-59.738101,3.939176,-59.298825,4.550232",
     "geom:latitude":4.220122,
     "geom:longitude":-59.534351,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"GY.UT.YP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879087,
-    "wof:geomhash":"b53abcb8efd77d1f7d75c3e7a469d584",
+    "wof:geomhash":"76a766c465e542f37b7ea37df5ccb486",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1091684343,
-    "wof:lastmodified":1627522169,
+    "wof:lastmodified":1695886637,
     "wof:name":"Yarong Paru - Good Hope",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/168/437/5/1091684375.geojson
+++ b/data/109/168/437/5/1091684375.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.577175,
-    "geom:area_square_m":7106221549.745233,
+    "geom:area_square_m":7106222170.090311,
     "geom:bbox":"-58.910376,4.538332,-57.657207,5.978234",
     "geom:latitude":5.298392,
     "geom:longitude":-58.389827,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.UD.UN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879088,
-    "wof:geomhash":"42cc9d388be7a50e70c66c11fdac9f80",
+    "wof:geomhash":"68b720b370bcea542f4a47851668dac6",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091684375,
-    "wof:lastmodified":1627522167,
+    "wof:lastmodified":1695886635,
     "wof:name":"Unorganized",
     "wof:parent_id":85671745,
     "wof:placetype":"county",

--- a/data/109/168/439/5/1091684395.geojson
+++ b/data/109/168/439/5/1091684395.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.091715,
-    "geom:area_square_m":1128140010.814255,
+    "geom:area_square_m":1128140641.461612,
     "geom:bbox":"-58.507176,5.612325,-58.115675,6.137194",
     "geom:latitude":5.86461,
     "geom:longitude":-58.32332,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.UD.CL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879090,
-    "wof:geomhash":"c498016fc7a374caf59073dd83862668",
+    "wof:geomhash":"076596b30efb6d754f30006bc5f18b19",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091684395,
-    "wof:lastmodified":1627522164,
+    "wof:lastmodified":1695886633,
     "wof:name":"Coomaka Lands",
     "wof:parent_id":85671745,
     "wof:placetype":"county",

--- a/data/109/168/444/1/1091684441.geojson
+++ b/data/109/168/444/1/1091684441.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.062141,
-    "geom:area_square_m":764835620.000162,
+    "geom:area_square_m":764835339.22303,
     "geom:bbox":"-58.254231,5.358089,-57.836885,5.626162",
     "geom:latitude":5.507102,
     "geom:longitude":-58.047666,
@@ -136,9 +136,10 @@
     "wof:concordances":{
         "hasc:id":"GY.UD.IT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879091,
-    "wof:geomhash":"cd358509f7b4de81276909e1f6272031",
+    "wof:geomhash":"89adfe3bad138c973aa5ec68b71b5472",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -148,7 +149,7 @@
         }
     ],
     "wof:id":1091684441,
-    "wof:lastmodified":1636494758,
+    "wof:lastmodified":1695886618,
     "wof:name":"Ituni",
     "wof:parent_id":85671745,
     "wof:placetype":"county",

--- a/data/109/168/448/1/1091684481.geojson
+++ b/data/109/168/448/1/1091684481.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.165182,
-    "geom:area_square_m":2034140312.188208,
+    "geom:area_square_m":2034139905.195421,
     "geom:bbox":"-58.739626,4.846995,-58.237293,5.469369",
     "geom:latitude":5.184275,
     "geom:longitude":-58.521536,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.UD.MH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879093,
-    "wof:geomhash":"158b9ebe5be499f07f5eb0b9e130ae93",
+    "wof:geomhash":"68f94953381a8061637eab63e3bfc1ed",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091684481,
-    "wof:lastmodified":1627522165,
+    "wof:lastmodified":1695886633,
     "wof:name":"Mabura Hill",
     "wof:parent_id":85671745,
     "wof:placetype":"county",

--- a/data/109/168/451/5/1091684515.geojson
+++ b/data/109/168/451/5/1091684515.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.093612,
-    "geom:area_square_m":1150943862.439803,
+    "geom:area_square_m":1150943209.838483,
     "geom:bbox":"-58.602913,5.786301,-58.378871,6.463453",
     "geom:latitude":6.114512,
     "geom:longitude":-58.499627,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.UD.MR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879094,
-    "wof:geomhash":"86be02c025aa980846568854d8c5af0b",
+    "wof:geomhash":"b7b9c5ffddc17f3769e085801e7db37f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091684515,
-    "wof:lastmodified":1627522166,
+    "wof:lastmodified":1695886634,
     "wof:name":"Makouria River",
     "wof:parent_id":85671745,
     "wof:placetype":"county",

--- a/data/109/168/455/5/1091684555.geojson
+++ b/data/109/168/455/5/1091684555.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.301471,
-    "geom:area_square_m":3712773386.583001,
+    "geom:area_square_m":3712773218.719978,
     "geom:bbox":"-58.399642,4.609268,-57.560282,5.802811",
     "geom:latitude":5.127056,
     "geom:longitude":-58.000042,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.UD.BR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879096,
-    "wof:geomhash":"7cb55a04e889e0dee1d9260b9352eee0",
+    "wof:geomhash":"65cb9bed76f9a47aa47d21a349cacb8d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091684555,
-    "wof:lastmodified":1627522163,
+    "wof:lastmodified":1695886632,
     "wof:name":"Berbice River settlements",
     "wof:parent_id":85671745,
     "wof:placetype":"county",

--- a/data/109/168/460/3/1091684603.geojson
+++ b/data/109/168/460/3/1091684603.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.07294,
-    "geom:area_square_m":893995228.701448,
+    "geom:area_square_m":893995076.475612,
     "geom:bbox":"-60.232311,7.393057,-59.756245,7.751897",
     "geom:latitude":7.598923,
     "geom:longitude":-60.030117,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.BA.MR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879097,
-    "wof:geomhash":"008b0cafbad6b4b458793c2206eefa98",
+    "wof:geomhash":"8afd120c757395ec02692245453a97f0",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091684603,
-    "wof:lastmodified":1627522166,
+    "wof:lastmodified":1695886634,
     "wof:name":"Matthews Ridge/Arakaka (Matakai)/Port Kaituma",
     "wof:parent_id":85671751,
     "wof:placetype":"county",

--- a/data/109/168/463/9/1091684639.geojson
+++ b/data/109/168/463/9/1091684639.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.135315,
-    "geom:area_square_m":1664554839.787654,
+    "geom:area_square_m":1664554949.07482,
     "geom:bbox":"-61.370145,5.529,-60.776171,6.020146",
     "geom:latitude":5.826346,
     "geom:longitude":-61.07972,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.CU.PA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879099,
-    "wof:geomhash":"5ff99c898d868d0ab3019251aee54576",
+    "wof:geomhash":"20b82f7f73e10592b069a5c061917908",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091684639,
-    "wof:lastmodified":1627522166,
+    "wof:lastmodified":1695886635,
     "wof:name":"Paruima",
     "wof:parent_id":85671773,
     "wof:placetype":"county",

--- a/data/109/168/468/1/1091684681.geojson
+++ b/data/109/168/468/1/1091684681.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.108688,
-    "geom:area_square_m":1339486081.385192,
+    "geom:area_square_m":1339486243.774148,
     "geom:bbox":"-60.1614,4.45244,-59.715575,4.900139",
     "geom:latitude":4.668744,
     "geom:longitude":-59.927847,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.PT.MR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879101,
-    "wof:geomhash":"8afd32d880f0ebe11bd4e1a7b093a803",
+    "wof:geomhash":"9f039bce052e93d7527a99ebf56b3384",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091684681,
-    "wof:lastmodified":1627522165,
+    "wof:lastmodified":1695886633,
     "wof:name":"Kurukabaru",
     "wof:parent_id":85671739,
     "wof:placetype":"county",

--- a/data/109/168/472/3/1091684723.geojson
+++ b/data/109/168/472/3/1091684723.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.138509,
-    "geom:area_square_m":1709061194.59118,
+    "geom:area_square_m":1709061295.208612,
     "geom:bbox":"-59.856446,3.48679,-59.256136,3.991747",
     "geom:latitude":3.7258,
     "geom:longitude":-59.52783,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"GY.UT.TJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879102,
-    "wof:geomhash":"76a5b81db33e8f660e2be8902cb95e8e",
+    "wof:geomhash":"080a9e78915166d898446d502f3e5b17",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1091684723,
-    "wof:lastmodified":1627522169,
+    "wof:lastmodified":1695886637,
     "wof:name":"Toka - Jakaretinga",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/168/477/1/1091684771.geojson
+++ b/data/109/168/477/1/1091684771.geojson
@@ -54,6 +54,7 @@
     "wof:concordances":{
         "hasc:id":"GY.EB.FG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879103,
     "wof:geomhash":"a73147789a262e860e49cc9407671b2c",
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1091684771,
-    "wof:lastmodified":1694498072,
+    "wof:lastmodified":1695886291,
     "wof:name":"Fyrish/Gibraltar",
     "wof:parent_id":85671757,
     "wof:placetype":"county",

--- a/data/109/168/478/7/1091684787.geojson
+++ b/data/109/168/478/7/1091684787.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.210523,
-    "geom:area_square_m":2591371513.984192,
+    "geom:area_square_m":2591371683.299017,
     "geom:bbox":"-59.583337,5.158702,-58.894396,5.73976",
     "geom:latitude":5.452899,
     "geom:longitude":-59.238287,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.PT.MK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879105,
-    "wof:geomhash":"83b3f86eeb58b94832115d7107946170",
+    "wof:geomhash":"7146dfb32e81636161f865521c5b79b1",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091684787,
-    "wof:lastmodified":1627522165,
+    "wof:lastmodified":1695886634,
     "wof:name":"Madhia+Kurubrong River+Mona Falls",
     "wof:parent_id":85671739,
     "wof:placetype":"county",

--- a/data/109/168/482/5/1091684825.geojson
+++ b/data/109/168/482/5/1091684825.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018586,
-    "geom:area_square_m":229131358.538854,
+    "geom:area_square_m":229131199.474005,
     "geom:bbox":"-59.782357,4.363341,-59.599481,4.539342",
     "geom:latitude":4.454921,
     "geom:longitude":-59.691973,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.PT.MM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879107,
-    "wof:geomhash":"19eca2e4fc211f4d1630a864fcfee519",
+    "wof:geomhash":"737368ca468f5285e628f0626bc9fc25",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091684825,
-    "wof:lastmodified":1627522166,
+    "wof:lastmodified":1695886635,
     "wof:name":"Monkey Mountain",
     "wof:parent_id":85671739,
     "wof:placetype":"county",

--- a/data/109/168/486/7/1091684867.geojson
+++ b/data/109/168/486/7/1091684867.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.208201,
-    "geom:area_square_m":2571266160.497977,
+    "geom:area_square_m":2571266116.435475,
     "geom:bbox":"-59.6777,2.493768,-59.208108,3.152441",
     "geom:latitude":2.845085,
     "geom:longitude":-59.416276,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"GY.UT.SC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879108,
-    "wof:geomhash":"6e982f2231797581770aad735c99abfb",
+    "wof:geomhash":"9ffab29e33faa1fc72d0b35d4ba2ff60",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1091684867,
-    "wof:lastmodified":1627522167,
+    "wof:lastmodified":1695886636,
     "wof:name":"Sand Creek - Dadanawa, Catunarib, Sawariwau",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/168/489/9/1091684899.geojson
+++ b/data/109/168/489/9/1091684899.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.195077,
-    "geom:area_square_m":2410276137.609026,
+    "geom:area_square_m":2410276695.665245,
     "geom:bbox":"-59.743332,1.913893,-59.107755,2.561227",
     "geom:latitude":2.261881,
     "geom:longitude":-59.45776,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"GY.UT.AK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879109,
-    "wof:geomhash":"e7eaca8aa25df8c3dcf7edbcbede340c",
+    "wof:geomhash":"40bfd087edf74869ce62abdec0afdebb",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1091684899,
-    "wof:lastmodified":1627522163,
+    "wof:lastmodified":1695886632,
     "wof:name":"Aishalton - Karaudanawa, Achiwib",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/168/494/5/1091684945.geojson
+++ b/data/109/168/494/5/1091684945.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042843,
-    "geom:area_square_m":527453365.990695,
+    "geom:area_square_m":527453380.359465,
     "geom:bbox":"-58.187189,5.162093,-57.938184,5.493251",
     "geom:latitude":5.346568,
     "geom:longitude":-58.056027,
@@ -70,9 +70,10 @@
     "wof:concordances":{
         "hasc:id":"GY.UD.KW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879111,
-    "wof:geomhash":"de3c49558a09067ca6e21dffa4172a9f",
+    "wof:geomhash":"b8863aff6b467474d83b1b939f107159",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1091684945,
-    "wof:lastmodified":1627522165,
+    "wof:lastmodified":1695886634,
     "wof:name":"Kwakwani",
     "wof:parent_id":85671745,
     "wof:placetype":"county",

--- a/data/109/168/497/5/1091684975.geojson
+++ b/data/109/168/497/5/1091684975.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.099303,
-    "geom:area_square_m":1227145178.029486,
+    "geom:area_square_m":1227145045.85492,
     "geom:bbox":"-59.756413,1.735269,-59.187324,2.242533",
     "geom:latitude":2.001983,
     "geom:longitude":-59.456377,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"GY.UT.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879112,
-    "wof:geomhash":"64686d56242a5c88ef1e400dd69ffde6",
+    "wof:geomhash":"fb427a73992d25ccaed5e4a9d291e81e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1091684975,
-    "wof:lastmodified":1627522166,
+    "wof:lastmodified":1695886635,
     "wof:name":"Marudi",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/168/497/7/1091684977.geojson
+++ b/data/109/168/497/7/1091684977.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024904,
-    "geom:area_square_m":305019266.305897,
+    "geom:area_square_m":305019273.217422,
     "geom:bbox":"-59.315744,7.793704,-59.123674,8.013549",
     "geom:latitude":7.901675,
     "geom:longitude":-59.220049,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.BA.UN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879114,
-    "wof:geomhash":"63347f50532b4655a32f783edcd6b7e4",
+    "wof:geomhash":"8c41d427bf0f03a3582d28b6f6742cd9",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091684977,
-    "wof:lastmodified":1627522167,
+    "wof:lastmodified":1695886636,
     "wof:name":"Unorganized",
     "wof:parent_id":85671751,
     "wof:placetype":"county",

--- a/data/109/168/498/1/1091684981.geojson
+++ b/data/109/168/498/1/1091684981.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.239981,
-    "geom:area_square_m":2960292024.34203,
+    "geom:area_square_m":2960292132.248048,
     "geom:bbox":"-59.442008,3.634114,-58.89,4.301761",
     "geom:latitude":3.964867,
     "geom:longitude":-59.154957,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"GY.UT.YW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879116,
-    "wof:geomhash":"ee3aaad062110427b6f2794cb843758e",
+    "wof:geomhash":"bd0b0b178c807229e24b8d9fe21070e0",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1091684981,
-    "wof:lastmodified":1627522169,
+    "wof:lastmodified":1695886637,
     "wof:name":"Yakarinta - Wowetta, Surama",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/168/498/5/1091684985.geojson
+++ b/data/109/168/498/5/1091684985.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016119,
-    "geom:area_square_m":198078707.186171,
+    "geom:area_square_m":198078707.18614,
     "geom:bbox":"-61.168059,6.23245756315,-60.9998043699,6.45895693462",
     "geom:latitude":6.375185,
     "geom:longitude":-61.08283,
@@ -94,9 +94,10 @@
     "wof:concordances":{
         "hasc:id":"GY.CU.AR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879117,
-    "wof:geomhash":"a4a6e55205e6e154a5943a1ab57b29c7",
+    "wof:geomhash":"290ea6ae4e4560c82850642f86fed65d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1091684985,
-    "wof:lastmodified":1566644373,
+    "wof:lastmodified":1695886350,
     "wof:name":"Arau",
     "wof:parent_id":85671773,
     "wof:placetype":"county",

--- a/data/109/168/503/1/1091685031.geojson
+++ b/data/109/168/503/1/1091685031.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.053413,
-    "geom:area_square_m":656724178.885409,
+    "geom:area_square_m":656724213.92341,
     "geom:bbox":"-58.114223,5.919558,-57.778554,6.352522",
     "geom:latitude":6.101072,
     "geom:longitude":-57.937607,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"GY.MA.SF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879119,
-    "wof:geomhash":"525170ba5dfa22c6768a8e89a3353aa5",
+    "wof:geomhash":"95a9b525d15806dfceb57642e23b468b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -89,7 +90,7 @@
         }
     ],
     "wof:id":1091685031,
-    "wof:lastmodified":1627522167,
+    "wof:lastmodified":1695886636,
     "wof:name":"St. Francis Mission",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/168/506/1/1091685061.geojson
+++ b/data/109/168/506/1/1091685061.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018316,
-    "geom:area_square_m":225241070.539355,
+    "geom:area_square_m":225240845.988824,
     "geom:bbox":"-58.397786,5.896108,-58.207103,6.068144",
     "geom:latitude":5.997007,
     "geom:longitude":-58.290664,
@@ -146,9 +146,10 @@
     "wof:concordances":{
         "hasc:id":"GY.UD.LM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879120,
-    "wof:geomhash":"184942810de6834d5a2dbbed6735e64e",
+    "wof:geomhash":"8d093869624e6db9726a9095f88f63de",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -158,7 +159,7 @@
         }
     ],
     "wof:id":1091685061,
-    "wof:lastmodified":1636494757,
+    "wof:lastmodified":1695886618,
     "wof:name":"Linden",
     "wof:parent_id":85671745,
     "wof:placetype":"county",

--- a/data/109/168/510/9/1091685109.geojson
+++ b/data/109/168/510/9/1091685109.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022852,
-    "geom:area_square_m":281612093.693595,
+    "geom:area_square_m":281612093.693605,
     "geom:bbox":"-59.7811626288,4.59928571099,-59.5886107415,4.80571379447",
     "geom:latitude":4.702868,
     "geom:longitude":-59.692816,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"GY.PT.PA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879121,
-    "wof:geomhash":"0e6300cb249bb07e4ecbf7ec923702d5",
+    "wof:geomhash":"eb87142eb8feb8ced741317adee346eb",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1091685109,
-    "wof:lastmodified":1566644373,
+    "wof:lastmodified":1695886350,
     "wof:name":"Paramakatoi",
     "wof:parent_id":85671739,
     "wof:placetype":"county",

--- a/data/109/168/515/5/1091685155.geojson
+++ b/data/109/168/515/5/1091685155.geojson
@@ -54,6 +54,7 @@
     "wof:concordances":{
         "hasc:id":"GY.EB.EB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879123,
     "wof:geomhash":"fb318ea2c0b14e11db67280c9ec07a65",
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1091685155,
-    "wof:lastmodified":1694498071,
+    "wof:lastmodified":1695886278,
     "wof:name":"Corentyne River",
     "wof:parent_id":85671757,
     "wof:placetype":"county",

--- a/data/109/168/519/7/1091685197.geojson
+++ b/data/109/168/519/7/1091685197.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.136178,
-    "geom:area_square_m":38732920844.455826,
+    "geom:area_square_m":38732920271.433067,
     "geom:bbox":"-59.635248,1.164724,-57.907328,4.279658",
     "geom:latitude":2.70097,
     "geom:longitude":-58.726916,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.UT.UN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879125,
-    "wof:geomhash":"7fa900d4ce1879f4ff24356c29a17342",
+    "wof:geomhash":"96af621db636266e00bdfa4b89112fc5",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091685197,
-    "wof:lastmodified":1627522168,
+    "wof:lastmodified":1695886636,
     "wof:name":"Unorganized",
     "wof:parent_id":85671743,
     "wof:placetype":"county",

--- a/data/109/168/524/5/1091685245.geojson
+++ b/data/109/168/524/5/1091685245.geojson
@@ -55,6 +55,7 @@
     "wof:concordances":{
         "hasc:id":"GY.EB.JC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879126,
     "wof:geomhash":"47bdb861fe66198d68c836c943b4ede4",
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1091685245,
-    "wof:lastmodified":1694639797,
+    "wof:lastmodified":1695886306,
     "wof:name":"Jackson Creek/Crabwood Creek",
     "wof:parent_id":85671757,
     "wof:placetype":"county",

--- a/data/109/168/529/3/1091685293.geojson
+++ b/data/109/168/529/3/1091685293.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000758,
-    "geom:area_square_m":9296507.831203,
+    "geom:area_square_m":9296471.084159,
     "geom:bbox":"-58.48083,7.024139,-58.464027,7.105139",
     "geom:latitude":7.063719,
     "geom:longitude":-58.473311,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.PM.GH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879128,
-    "wof:geomhash":"428dce94c9a282e81a41b5ef4b64be02",
+    "wof:geomhash":"5a57f8c8e475fcc120e7ff37d1e1e13a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091685293,
-    "wof:lastmodified":1627522167,
+    "wof:lastmodified":1695886636,
     "wof:name":"Sparta/Bonasika and Rest of Essequibo Islands",
     "wof:parent_id":85671767,
     "wof:placetype":"county",

--- a/data/109/168/533/1/1091685331.geojson
+++ b/data/109/168/533/1/1091685331.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00207,
-    "geom:area_square_m":25435804.609502,
+    "geom:area_square_m":25435690.013014,
     "geom:bbox":"-58.684647,6.357329,-58.614582,6.413135",
     "geom:latitude":6.381887,
     "geom:longitude":-58.647678,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.CU.AG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879129,
-    "wof:geomhash":"23f57fb03c7d47872a8d4a1350aee70d",
+    "wof:geomhash":"0706f14daabf76c9e06ab74210aaa3e3",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091685331,
-    "wof:lastmodified":1627522163,
+    "wof:lastmodified":1695886632,
     "wof:name":"Agatash",
     "wof:parent_id":85671773,
     "wof:placetype":"county",

--- a/data/109/168/536/7/1091685367.geojson
+++ b/data/109/168/536/7/1091685367.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000263,
-    "geom:area_square_m":3235952.933657,
+    "geom:area_square_m":3235912.395213,
     "geom:bbox":"-58.638956,6.396178,-58.618752,6.420417",
     "geom:latitude":6.410384,
     "geom:longitude":-58.628277,
@@ -130,9 +130,10 @@
     "wof:concordances":{
         "hasc:id":"GY.CU.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879130,
-    "wof:geomhash":"573d1bce2e8a7949bfe1b33525521504",
+    "wof:geomhash":"a1e125711f90214f2be338a5db0b6f68",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -142,7 +143,7 @@
         }
     ],
     "wof:id":1091685367,
-    "wof:lastmodified":1636494757,
+    "wof:lastmodified":1695886618,
     "wof:name":"Bartica",
     "wof:parent_id":85671773,
     "wof:placetype":"county",

--- a/data/109/168/540/9/1091685409.geojson
+++ b/data/109/168/540/9/1091685409.geojson
@@ -129,6 +129,7 @@
     "wof:concordances":{
         "hasc:id":"GY.EB.CM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879132,
     "wof:geomhash":"c5332f9a7a85bb50d93bb15c87dc8944",
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1091685409,
-    "wof:lastmodified":1694498096,
+    "wof:lastmodified":1695886618,
     "wof:name":"Corriverton",
     "wof:parent_id":85671757,
     "wof:placetype":"county",

--- a/data/109/168/545/3/1091685453.geojson
+++ b/data/109/168/545/3/1091685453.geojson
@@ -54,6 +54,7 @@
     "wof:concordances":{
         "hasc:id":"GY.EB.EN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879133,
     "wof:geomhash":"dd5f00141e32343a068121347c50c9cd",
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1091685453,
-    "wof:lastmodified":1694498072,
+    "wof:lastmodified":1695886291,
     "wof:name":"Enfield/New Doe Park",
     "wof:parent_id":85671757,
     "wof:placetype":"county",

--- a/data/109/168/547/9/1091685479.geojson
+++ b/data/109/168/547/9/1091685479.geojson
@@ -162,6 +162,7 @@
     "wof:concordances":{
         "hasc:id":"GY.EB.NA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879135,
     "wof:geomhash":"38e85bc403475790031c18024ed0efd3",
@@ -174,7 +175,7 @@
         }
     ],
     "wof:id":1091685479,
-    "wof:lastmodified":1694498096,
+    "wof:lastmodified":1695886618,
     "wof:name":"New Amsterdam",
     "wof:parent_id":85671757,
     "wof:placetype":"county",

--- a/data/109/168/552/5/1091685525.geojson
+++ b/data/109/168/552/5/1091685525.geojson
@@ -54,6 +54,7 @@
     "wof:concordances":{
         "hasc:id":"GY.EB.NO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879137,
     "wof:geomhash":"6c5b0a3ff59533e83f795cd17026fb05",
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1091685525,
-    "wof:lastmodified":1694498074,
+    "wof:lastmodified":1695886360,
     "wof:name":"No.38/Ordnance Fortlands",
     "wof:parent_id":85671757,
     "wof:placetype":"county",

--- a/data/109/168/557/1/1091685571.geojson
+++ b/data/109/168/557/1/1091685571.geojson
@@ -54,6 +54,7 @@
     "wof:concordances":{
         "hasc:id":"GY.EB.CF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879138,
     "wof:geomhash":"593a35c31f2dcf259d39c2907dea9410",
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1091685571,
-    "wof:lastmodified":1694498071,
+    "wof:lastmodified":1695886272,
     "wof:name":"Cane Field/Enterprise",
     "wof:parent_id":85671757,
     "wof:placetype":"county",

--- a/data/109/168/560/1/1091685601.geojson
+++ b/data/109/168/560/1/1091685601.geojson
@@ -63,6 +63,7 @@
     "wof:concordances":{
         "hasc:id":"GY.EB.CT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879140,
     "wof:geomhash":"18a04702ae1a847a8079e2b6e15eb9eb",
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091685601,
-    "wof:lastmodified":1694498071,
+    "wof:lastmodified":1695886272,
     "wof:name":"Canje River",
     "wof:parent_id":85671757,
     "wof:placetype":"county",

--- a/data/109/168/573/3/1091685733.geojson
+++ b/data/109/168/573/3/1091685733.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003215,
-    "geom:area_square_m":39471961.041962,
+    "geom:area_square_m":39472085.172989,
     "geom:bbox":"-58.078793,6.708436,-58.019208,6.820275",
     "geom:latitude":6.765627,
     "geom:longitude":-58.049879,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.DE.LR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879144,
-    "wof:geomhash":"c15877964ed09d52fbda70d19f6324e8",
+    "wof:geomhash":"218be0fdeeae303370763d50fb656fac",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091685733,
-    "wof:lastmodified":1627522165,
+    "wof:lastmodified":1695886634,
     "wof:name":"La Reconnaissance/Mon Repos",
     "wof:parent_id":85671761,
     "wof:placetype":"county",

--- a/data/109/168/576/5/1091685765.geojson
+++ b/data/109/168/576/5/1091685765.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003283,
-    "geom:area_square_m":40308112.890141,
+    "geom:area_square_m":40308042.84189,
     "geom:bbox":"-58.113883,6.720369,-58.057148,6.832064",
     "geom:latitude":6.774641,
     "geom:longitude":-58.085117,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.DE.LB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879146,
-    "wof:geomhash":"fa5f8c2e75369722276d2d7889c5e840",
+    "wof:geomhash":"7e0e2f72906079edfe6b69584d4b57c8",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091685765,
-    "wof:lastmodified":1627522165,
+    "wof:lastmodified":1695886634,
     "wof:name":"La Bonne Intention/Better Hope",
     "wof:parent_id":85671761,
     "wof:placetype":"county",

--- a/data/109/168/579/1/1091685791.geojson
+++ b/data/109/168/579/1/1091685791.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000598,
-    "geom:area_square_m":7341917.346924,
+    "geom:area_square_m":7342125.51239,
     "geom:bbox":"-58.083148,6.718858,-58.050875,6.823012",
     "geom:latitude":6.773948,
     "geom:longitude":-58.066614,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GY.DE.TB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879147,
-    "wof:geomhash":"8733859fbde9ab193df3e10956d347f3",
+    "wof:geomhash":"9dff4490f4e8853c77c38a16faa7d46d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091685791,
-    "wof:lastmodified":1627522169,
+    "wof:lastmodified":1695886637,
     "wof:name":"Triumph/Beterverwagting",
     "wof:parent_id":85671761,
     "wof:placetype":"county",

--- a/data/109/168/582/9/1091685829.geojson
+++ b/data/109/168/582/9/1091685829.geojson
@@ -54,6 +54,7 @@
     "wof:concordances":{
         "hasc:id":"GY.EB.CT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879149,
     "wof:geomhash":"8efaaec5433133e5d506c6178560d402",
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1091685829,
-    "wof:lastmodified":1694498072,
+    "wof:lastmodified":1695886287,
     "wof:name":"East Bank Berbice",
     "wof:parent_id":85671757,
     "wof:placetype":"county",

--- a/data/109/168/585/9/1091685859.geojson
+++ b/data/109/168/585/9/1091685859.geojson
@@ -54,6 +54,7 @@
     "wof:concordances":{
         "hasc:id":"GY.MA.GN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879150,
     "wof:geomhash":"b3879158a2ab409dca9e9ff2fd735aaa",
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1091685859,
-    "wof:lastmodified":1694498072,
+    "wof:lastmodified":1695886301,
     "wof:name":"Hampshire/Kilcoy",
     "wof:parent_id":85671757,
     "wof:placetype":"county",

--- a/data/109/168/590/7/1091685907.geojson
+++ b/data/109/168/590/7/1091685907.geojson
@@ -57,6 +57,7 @@
     "wof:concordances":{
         "hasc:id":"GY.EB.RH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879152,
     "wof:geomhash":"10d44378ed7865af47597e6bf287d667",
@@ -69,7 +70,7 @@
         }
     ],
     "wof:id":1091685907,
-    "wof:lastmodified":1694498048,
+    "wof:lastmodified":1695886635,
     "wof:name":"Rose Hall",
     "wof:parent_id":85671757,
     "wof:placetype":"county",

--- a/data/109/168/595/5/1091685955.geojson
+++ b/data/109/168/595/5/1091685955.geojson
@@ -54,6 +54,7 @@
     "wof:concordances":{
         "hasc:id":"GY.EB.JP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879153,
     "wof:geomhash":"4356147b1b2990ab90d313494f20c9e4",
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1091685955,
-    "wof:lastmodified":1694498073,
+    "wof:lastmodified":1695886310,
     "wof:name":"John/Port Mourant",
     "wof:parent_id":85671757,
     "wof:placetype":"county",

--- a/data/117/561/273/5/1175612735.geojson
+++ b/data/117/561/273/5/1175612735.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005262,
-    "geom:area_square_m":64618034.329151,
+    "geom:area_square_m":64618145.034966,
     "geom:bbox":"-58.053833,6.672469,-57.977411,6.803025",
     "geom:latitude":6.736206,
     "geom:longitude":-58.018616,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"GY.DE.FB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879141,
-    "wof:geomhash":"a9add417a15419a2280346c39fc3917c",
+    "wof:geomhash":"c898c4e7e8b8afbaa3b773d71c2f9e3d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1175612735,
-    "wof:lastmodified":1627522164,
+    "wof:lastmodified":1695886633,
     "wof:name":"Foulis/Buxton",
     "wof:parent_id":85671761,
     "wof:placetype":"county",

--- a/data/117/561/273/7/1175612737.geojson
+++ b/data/117/561/273/7/1175612737.geojson
@@ -56,6 +56,7 @@
     "wof:concordances":{
         "hasc:id":"GY.ES.SB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879029,
     "wof:geomhash":"8597ffc9f20b69cf0aec2198bc0746b9",
@@ -68,7 +69,7 @@
         }
     ],
     "wof:id":1175612737,
-    "wof:lastmodified":1694498076,
+    "wof:lastmodified":1695886403,
     "wof:name":"Sparta/Bonasika and Rest of Essequibo Islands",
     "wof:parent_id":85671767,
     "wof:placetype":"county",

--- a/data/117/561/273/9/1175612739.geojson
+++ b/data/117/561/273/9/1175612739.geojson
@@ -56,6 +56,7 @@
     "wof:concordances":{
         "hasc:id":"GY.ES.SB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GY",
     "wof:created":1473879026,
     "wof:geomhash":"699c27e874084926bb49db0495d3cb7d",
@@ -68,7 +69,7 @@
         }
     ],
     "wof:id":1175612739,
-    "wof:lastmodified":1694498076,
+    "wof:lastmodified":1695886403,
     "wof:name":"Sparta/Bonasika and Rest of Essequibo Islands",
     "wof:parent_id":85671767,
     "wof:placetype":"county",

--- a/data/856/323/97/85632397.geojson
+++ b/data/856/323/97/85632397.geojson
@@ -1142,6 +1142,7 @@
         "hasc:id":"GY",
         "icao:code":"8R",
         "ioc:id":"GUY",
+        "iso:code":"GY",
         "itu:id":"GUY",
         "loc:id":"n80061018",
         "m49:code":"328",
@@ -1156,6 +1157,7 @@
         "wk:page":"Guyana",
         "wmo:id":"GY"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GY",
     "wof:country_alpha3":"GUY",
     "wof:geom_alt":[
@@ -1179,7 +1181,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1694639585,
+    "wof:lastmodified":1695881246,
     "wof:name":"Guyana",
     "wof:parent_id":102191577,
     "wof:placetype":"country",

--- a/data/856/717/37/85671737.geojson
+++ b/data/856/717/37/85671737.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.334119,
-    "geom:area_square_m":4107208280.264488,
+    "geom:area_square_m":4107208758.252256,
     "geom:bbox":"-58.151081,5.78443,-57.529972,6.711954",
     "geom:latitude":6.206524,
     "geom:longitude":-57.84426,
@@ -245,11 +245,13 @@
         "gn:id":3378840,
         "gp:id":2345606,
         "hasc:id":"GY.EB",
+        "iso:code":"GY-EB",
         "iso:id":"GY-EB",
         "qs_pg:id":1251810,
         "wd:id":"Q1277758",
         "wk:page":"East Berbice-Corentyne"
     },
+    "wof:concordances_official":"iso:code",
     "wof:controlled":[
         "wof:belongsto",
         "wof:hierarchy",
@@ -260,7 +262,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"83c21771afbefdf256dc85a27118fbf9",
+    "wof:geomhash":"469215c1b9c1a8bb21f8d52c7cc5e92c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -275,7 +277,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690930164,
+    "wof:lastmodified":1695884775,
     "wof:name":"Mahaica-Berbice",
     "wof:parent_id":85632397,
     "wof:placetype":"region",

--- a/data/856/717/39/85671739.geojson
+++ b/data/856/717/39/85671739.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.577625,
-    "geom:area_square_m":19437145795.167885,
+    "geom:area_square_m":19437146569.782566,
     "geom:bbox":"-60.1614,4.058797,-58.357888,5.73976",
     "geom:latitude":4.857721,
     "geom:longitude":-59.302009,
@@ -282,17 +282,19 @@
         "gn:id":3376386,
         "gp:id":2345610,
         "hasc:id":"GY.PT",
+        "iso:code":"GY-PT",
         "iso:id":"GY-PT",
         "qs_pg:id":1285239,
         "unlc:id":"GY-PT",
         "wd:id":"Q1454035",
         "wk:page":"Potaro-Siparuni"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fe072edaa49f0d5083a644d51a2ad6ce",
+    "wof:geomhash":"4a72ab82ff0d1c782d1d0b28cba4851d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -307,7 +309,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690930164,
+    "wof:lastmodified":1695884775,
     "wof:name":"Potaro-Siparuni",
     "wof:parent_id":85632397,
     "wof:placetype":"region",

--- a/data/856/717/43/85671743.geojson
+++ b/data/856/717/43/85671743.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.606112,
-    "geom:area_square_m":56880625056.410301,
+    "geom:area_square_m":56880624155.410912,
     "geom:bbox":"-59.991686,1.164724,-57.907328,4.550232",
     "geom:latitude":2.833418,
     "geom:longitude":-58.973155,
@@ -270,16 +270,18 @@
         "gn:id":3375469,
         "gp:id":2345611,
         "hasc:id":"GY.UD",
+        "iso:code":"GY-UD",
         "iso:id":"GY-UD",
         "qs_pg:id":219558,
         "wd:id":"Q1309042",
         "wk:page":"Upper Demerara-Berbice"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b36055d737c37698a4193940daaa2106",
+    "wof:geomhash":"b5222683cbba9cbb315f72cf48877fed",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -294,7 +296,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690930164,
+    "wof:lastmodified":1695884774,
     "wof:name":"Upper Takutu-Upper Essequibo",
     "wof:parent_id":85632397,
     "wof:placetype":"region",

--- a/data/856/717/45/85671745.geojson
+++ b/data/856/717/45/85671745.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.352454,
-    "geom:area_square_m":16649749178.302364,
+    "geom:area_square_m":16649748710.877375,
     "geom:bbox":"-58.910376,4.538332,-57.560282,6.463453",
     "geom:latitude":5.361726,
     "geom:longitude":-58.294479,
@@ -264,16 +264,18 @@
         "gn:id":3375463,
         "gp:id":2345612,
         "hasc:id":"GY.UT",
+        "iso:code":"GY-UT",
         "iso:id":"GY-UT",
         "qs_pg:id":219559,
         "wd:id":"Q1516381",
         "wk:page":"Upper Takutu-Upper Essequibo"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f0ff7def3b2ec549a9794dbf0600c5e5",
+    "wof:geomhash":"7567d742b6064647f9761c43bfd34cd2",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -288,7 +290,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690930163,
+    "wof:lastmodified":1695884775,
     "wof:name":"Upper Demerara-Berbice",
     "wof:parent_id":85632397,
     "wof:placetype":"region",

--- a/data/856/717/51/85671751.geojson
+++ b/data/856/717/51/85671751.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.604274,
-    "geom:area_square_m":19661811981.398308,
+    "geom:area_square_m":19661812819.915329,
     "geom:bbox":"-60.720363,6.982384,-58.791649,8.525899",
     "geom:latitude":7.617539,
     "geom:longitude":-59.74753,
@@ -287,17 +287,19 @@
         "gn:id":3379515,
         "gp:id":2345603,
         "hasc:id":"GY.BA",
+        "iso:code":"GY-BA",
         "iso:id":"GY-BA",
         "qs_pg:id":59638,
         "unlc:id":"GY-BA",
         "wd:id":"Q537740",
         "wk:page":"Barima-Waini"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cce043b6784836c3eac4f3cfc6e287e1",
+    "wof:geomhash":"2f8f73ff747af64375f03ee5fa992c0e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -312,7 +314,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690930162,
+    "wof:lastmodified":1695884774,
     "wof:name":"Barima-Waini",
     "wof:parent_id":85632397,
     "wof:placetype":"region",

--- a/data/856/717/53/85671753.geojson
+++ b/data/856/717/53/85671753.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.488537,
-    "geom:area_square_m":5993572716.251932,
+    "geom:area_square_m":5993573041.830317,
     "geom:bbox":"-59.240851,6.717724,-58.475639,7.66806",
     "geom:latitude":7.169983,
     "geom:longitude":-58.8413,
@@ -267,16 +267,18 @@
         "gn:id":3379023,
         "gp:id":2345604,
         "hasc:id":"GY.CU",
+        "iso:code":"GY-CU",
         "iso:id":"GY-CU",
         "qs_pg:id":1285238,
         "wd:id":"Q1146777",
         "wk:page":"Cuyuni-Mazaruni"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9f44e03194a7c9cbf63638cdbd153ddc",
+    "wof:geomhash":"3074799cb47a29ee9433502a065610f1",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -291,7 +293,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690930164,
+    "wof:lastmodified":1695884775,
     "wof:name":"Pomeroon-Supenaam",
     "wof:parent_id":85632397,
     "wof:placetype":"region",

--- a/data/856/717/57/85671757.geojson
+++ b/data/856/717/57/85671757.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.938098,
-    "geom:area_square_m":36255984144.182953,
+    "geom:area_square_m":36255983596.857361,
     "geom:bbox":"-58.444785,1.499532,-56.49112,6.337472",
     "geom:latitude":3.395416,
     "geom:longitude":-57.654166,
@@ -273,16 +273,18 @@
         "gn:id":3378950,
         "gp:id":2345605,
         "hasc:id":"GY.DE",
+        "iso:code":"GY-DE",
         "iso:id":"GY-DE",
         "qs_pg:id":318493,
         "wd:id":"Q1185362",
         "wk:page":"Demerara-Mahaica"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"07d814633ed04dd338c0e94a50e929b6",
+    "wof:geomhash":"2f3d05b9b6b421c80ff71903f5f1cae5",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -297,7 +299,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690930162,
+    "wof:lastmodified":1695884774,
     "wof:name":"East Berbice-Corentyne",
     "wof:parent_id":-1,
     "wof:placetype":"region",

--- a/data/856/717/61/85671761.geojson
+++ b/data/856/717/61/85671761.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.17548,
-    "geom:area_square_m":2155907830.092078,
+    "geom:area_square_m":2155908153.649142,
     "geom:bbox":"-58.31248,6.087378,-57.878383,6.836222",
     "geom:latitude":6.494602,
     "geom:longitude":-58.120992,
@@ -165,16 +165,18 @@
         "gn:id":3378741,
         "gp:id":2345607,
         "hasc:id":"GY.ES",
+        "iso:code":"GY-ES",
         "iso:id":"GY-ES",
         "qs_pg:id":894889,
         "wd:id":"Q1368802",
         "wk:page":"Essequibo Islands-West Demerara"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ce5d859ec6d91e0218074399c170fdfa",
+    "wof:geomhash":"16b77b453378b3e2869558a339da2bf1",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -189,7 +191,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636494753,
+    "wof:lastmodified":1695884774,
     "wof:name":"Demerara-Mahaica",
     "wof:parent_id":85632397,
     "wof:placetype":"region",

--- a/data/856/717/67/85671767.geojson
+++ b/data/856/717/67/85671767.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.266772,
-    "geom:area_square_m":3276761951.199584,
+    "geom:area_square_m":3276761425.639224,
     "geom:bbox":"-58.870959,6.089988,-58.180328,7.105139",
     "geom:latitude":6.607888,
     "geom:longitude":-58.464593,
@@ -234,16 +234,18 @@
         "gn:id":3377274,
         "gp:id":2345608,
         "hasc:id":"GY.MA",
+        "iso:code":"GY-MA",
         "iso:id":"GY-MA",
         "qs_pg:id":268609,
         "wd:id":"Q1466671",
         "wk:page":"Mahaica-Berbice"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4b47bfe2b54e632a9442134df9f9aff4",
+    "wof:geomhash":"be184c67983821b254c2d73b89cb057f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -258,7 +260,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690930163,
+    "wof:lastmodified":1695884774,
     "wof:name":"Essequibo Islands-West Demerara",
     "wof:parent_id":85632397,
     "wof:placetype":"region",

--- a/data/856/717/73/85671773.geojson
+++ b/data/856/717/73/85671773.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.866731,
-    "geom:area_square_m":47536152916.072479,
+    "geom:area_square_m":47536152624.332275,
     "geom:bbox":"-61.414728,5.170512,-58.578167,7.118659",
     "geom:latitude":6.150525,
     "geom:longitude":-59.954335,
@@ -267,16 +267,18 @@
         "gn:id":3376407,
         "gp:id":2345609,
         "hasc:id":"GY.PM",
+        "iso:code":"GY-PM",
         "iso:id":"GY-PM",
         "qs_pg:id":229376,
         "wd:id":"Q680382",
         "wk:page":"Pomeroon-Supenaam"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"758f1514e3c90b2180f42edc52e7b8b8",
+    "wof:geomhash":"8d8721c8ed57d5f0341e72a40cc62398",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -291,7 +293,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690930163,
+    "wof:lastmodified":1695884775,
     "wof:name":"Cuyuni-Mazaruni",
     "wof:parent_id":85632397,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.